### PR TITLE
Investigate and fix next round 400 error

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -40,7 +40,10 @@ def index():
 
 @app.route('/api/start_game', methods=['POST'])
 def start_game():
-    data = request.json
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': 'No JSON data provided'}), 400
+    
     lead_names = data.get('leads', '').split(',')
     follow_names = data.get('follows', '').split(',')
     judge_names = data.get('judges', '').split(',')
@@ -225,13 +228,18 @@ def judge_follows():
 
 @app.route('/api/next_round', methods=['POST'])
 def next_round():
-    data = request.json
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': 'No JSON data provided'}), 400
+    
     session_id = data.get('session_id')
     
-    if session_id not in games:
-        return jsonify({'error': 'Game not found'}), 404
+    if not session_id:
+        return jsonify({'error': 'Missing session_id'}), 400
     
-    game = games[session_id]
+    game = games.get(session_id)
+    if not game:
+        return jsonify({'error': 'Invalid session ID'}), 400
     game.next_round()
     state = game.get_game_state()
     
@@ -244,13 +252,18 @@ def next_round():
 
 @app.route('/api/end_game', methods=['POST'])
 def end_game():
-    data = request.json
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': 'No JSON data provided'}), 400
+    
     session_id = data.get('session_id')
     
-    if session_id not in games:
-        return jsonify({'error': 'Game not found'}), 404
+    if not session_id:
+        return jsonify({'error': 'Missing session_id'}), 400
     
-    game = games[session_id]
+    game = games.get(session_id)
+    if not game:
+        return jsonify({'error': 'Invalid session ID'}), 400
     leads, follows = game.finalize_results()
     
     # Format the results - include all leads


### PR DESCRIPTION
Add input validation to `/api/start_game`, `/api/next_round`, and `/api/end_game` endpoints.

Previously, these endpoints could return generic 400 errors due to missing or malformed JSON data, or the absence of a required `session_id`. This change introduces `request.get_json()` for safer JSON parsing and explicit checks for required parameters, providing more specific error messages like "No JSON data provided", "Missing session_id", or "Invalid session ID".

---

[Slack Thread](https://husslentussleapp.slack.com/archives/D097WP15ZRP/p1753453203386359?thread_ts=1753453203.386359&cid=D097WP15ZRP) • [Open in Web](https://www.cursor.com/agents?id=bc-da36e503-61b2-4389-a557-f5b099af6b15) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-da36e503-61b2-4389-a557-f5b099af6b15)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)