### PR TITLE
Implement tie-breaking battle rounds

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -12,7 +12,11 @@ class Contestant:
 
 class Round:
     def __init__(
-        self, round_num, lead_votes, follow_votes, judges, contestant_judges, session_id
+        self, round_num, lead_votes, follow_votes, judges, contestant_judges, session_id,
+        is_tiebreak: bool = False,
+        tiebreak_role: str | None = None,
+        tiebreak_heat: int | None = None,
+        tiebreak_subround: int | None = None,
     ) -> None:
         self.round_num = round_num
         self.lead_votes = lead_votes
@@ -25,6 +29,11 @@ class Round:
         self.follow_winner = None  # Will store the name of the follow winner
         self.song_info = None  # Will store song information for this round
         self.session_id = session_id  # Store the session ID for this round
+        # Tiebreak metadata
+        self.is_tiebreak = is_tiebreak
+        self.tiebreak_role = tiebreak_role
+        self.tiebreak_heat = tiebreak_heat
+        self.tiebreak_subround = tiebreak_subround
 
 
 class ContestantQueueProxy:
@@ -52,8 +61,13 @@ class ContestantQueueProxy:
                 names.add(self._game.pair_2[1].name)
         return names
 
-    # Iteration hides current competitors
+        # Iteration hides current competitors
     def __iter__(self):
+        # During a No Contest transition, show the full backing queue including current competitors
+        if getattr(self._game, 'no_contest_pending', False):
+            for item in self._backing():
+                yield item
+            return
         filtered = self._filtered_names()
         for item in self._backing():
             if item.name not in filtered:
@@ -170,9 +184,268 @@ class Game:
         self.carryover_lead_winner = None
         self.carryover_follow_winner = None
         
+        # Tiebreak state
+        self.tiebreak_active = False
+        self.tiebreak_role: str | None = None  # 'lead' or 'follow'
+        self.tiebreak_competitors: list[Contestant] = []
+        self.tiebreak_partners: list[Contestant] = []
+        self.tiebreak_scores: dict[str, int] = {}
+        self.tiebreak_heat_index: int = 0  # 0-based
+        self._tiebreak_pairs_in_current_heat: int = 0
+        self._tiebreak_pairs_boundary_after_next_judge: bool = False
+        self._tiebreak_pair_stream_index: int = 0  # counts across heats
+        self._tiebreak_pair_buffer: list[tuple[Contestant, Contestant]] = []  # next pairs to use in subrounds (each is (lead, follow))
+        self._tiebreak_rotation_size: int = 0
+        self.tiebreak_winner_lead: str | None = None
+        self.tiebreak_winner_follow: str | None = None
+        
         # Start the first round
         self.start_round()
-        
+    
+    def detect_top_ties(self, role: str) -> list[str]:
+        """Return names of contestants tied for top points for the given role."""
+        if role not in ("lead", "follow"):
+            return []
+        pool = self.initial_leads if role == "lead" else self.initial_follows
+        if not pool:
+            return []
+        max_points = max(c.points for c in pool)
+        leaders = [c.name for c in pool if c.points == max_points]
+        return leaders if len(leaders) > 1 else []
+    
+    def start_tiebreak(self, role: str, competitor_names: list[str] | None = None):
+        """Initialize tiebreak state for the given role. If competitor_names is None,
+        use the contestants tied for top points."""
+        assert role in ("lead", "follow"), "role must be 'lead' or 'follow'"
+        if competitor_names is None:
+            competitor_names = self.detect_top_ties(role)
+        if not competitor_names or len(competitor_names) < 2:
+            raise ValueError("Need at least two tied competitors to start tiebreak")
+        # Map names to Contestant objects
+        name_to_obj = {c.name: c for c in (self.initial_leads if role == "lead" else self.initial_follows)}
+        competitors: list[Contestant] = []
+        for n in competitor_names:
+            if n not in name_to_obj:
+                raise ValueError(f"Invalid competitor: {n}")
+            competitors.append(name_to_obj[n])
+        # Set state
+        self.tiebreak_active = True
+        self.tiebreak_role = role
+        self.tiebreak_competitors = competitors
+        self.tiebreak_partners = []
+        self.tiebreak_scores = {c.name: 0 for c in competitors}
+        self.tiebreak_heat_index = 0
+        self._tiebreak_pairs_in_current_heat = 0
+        self._tiebreak_pair_stream_index = 0
+        self._tiebreak_pair_buffer = []
+        self._tiebreak_rotation_size = len(competitors)
+        # Clear any current round pairing buffer to avoid mixing with normal flow
+        return {
+            "role": role,
+            "competitors": [c.name for c in competitors]
+        }
+    
+    def set_tiebreak_partners(self, assignments: list[tuple[str, str]]):
+        """Assignments is list of (competitor_name, partner_name). Partner names must be unique
+        and from the opposite role original pool."""
+        if not self.tiebreak_active or not self.tiebreak_role:
+            raise ValueError("No active tiebreak")
+        role = self.tiebreak_role
+        opp_pool = self.initial_follows if role == "lead" else self.initial_leads
+        opp_map = {c.name: c for c in opp_pool}
+        # Validate uniqueness and existence
+        seen_partners: set[str] = set()
+        partner_by_comp: dict[str, Contestant] = {}
+        for comp_name, partner_name in assignments:
+            if comp_name not in {c.name for c in self.tiebreak_competitors}:
+                raise ValueError(f"Unknown tiebreak competitor: {comp_name}")
+            if partner_name not in opp_map:
+                raise ValueError(f"Invalid partner: {partner_name}")
+            if partner_name in seen_partners:
+                raise ValueError(f"Duplicate partner selection: {partner_name}")
+            seen_partners.add(partner_name)
+            partner_by_comp[comp_name] = opp_map[partner_name]
+        # Preserve competitor order for rotation
+        partners_ordered: list[Contestant] = []
+        for comp in self.tiebreak_competitors:
+            partners_ordered.append(partner_by_comp[comp.name])
+        self.tiebreak_partners = partners_ordered
+        # Initialize first subround
+        self._prepare_next_tiebreak_subround()
+        return self._get_tiebreak_state_payload(include_next_pairs=True)
+    
+    def _tiebreak_pair_generator(self):
+        """Yield pairs for each heat rotation in order. Each yielded item is a tuple
+        (lead, follow) representing a couple on the floor. Generates K pairs per heat.
+        We use self.tiebreak_heat_index to know current heat, but this generator
+        yields from the current heat onward."""
+        K = self._tiebreak_rotation_size
+        if K <= 0:
+            return
+        # Start from current heat index
+        r = self.tiebreak_heat_index
+        while True:
+            for i, comp in enumerate(self.tiebreak_competitors):
+                partner_idx = (i + r) % K
+                partner = self.tiebreak_partners[partner_idx]
+                # Couple placement depends on role: couple is always (lead, follow)
+                if self.tiebreak_role == 'lead':
+                    yield (comp, partner)  # comp is lead
+                else:
+                    yield (partner, comp)  # comp is follow
+            # Advance to next heat after K pairs
+            r += 1
+
+    def _get_tiebreak_state_payload(self, include_next_pairs: bool = False) -> dict:
+        state = {
+            "active": self.tiebreak_active,
+            "role": self.tiebreak_role,
+            "competitors": [c.name for c in self.tiebreak_competitors],
+            "partners": [c.name for c in self.tiebreak_partners],
+            "scores": dict(self.tiebreak_scores),
+            "heat_index": getattr(self, 'tiebreak_heat_index', 0),
+        }
+        if include_next_pairs and self.pair_1 and self.pair_2:
+            state["current_pairs"] = self.get_current_pairs()
+        return state
+
+    def _fill_tiebreak_pair_buffer(self):
+        """Ensure we have at least two pairs buffered for the next subround.
+        We pull from the infinite generator defined by rotation without mutating heat stats here."""
+        gen = getattr(self, '_tiebreak_gen', None)
+        if gen is None:
+            self._tiebreak_gen = self._tiebreak_pair_generator()
+            gen = self._tiebreak_gen
+        while len(self._tiebreak_pair_buffer) < 2:
+            pair = next(gen)
+            self._tiebreak_pair_buffer.append(pair)
+
+    def _prepare_next_tiebreak_subround(self):
+        """Prepare Game.pair_1 and Game.pair_2 for the next tiebreak subround and create Round."""
+        if not self.tiebreak_active:
+            raise ValueError("No active tiebreak to prepare")
+        # Buffer two pairs
+        self._fill_tiebreak_pair_buffer()
+        p1 = self._tiebreak_pair_buffer.pop(0)
+        p2 = self._tiebreak_pair_buffer.pop(0)
+        # Assign pairs
+        self.pair_1 = p1
+        self.pair_2 = p2
+        # Judges for this subround
+        self.contestant_judges = self.get_contestant_judges()
+        # Create round with tiebreak meta
+        self.current_round = Round(
+            self.round_num,
+            {},
+            {},
+            self.guest_judges,
+            [j.name for j in self.contestant_judges],
+            self.session_id,
+            is_tiebreak=True,
+            tiebreak_role=self.tiebreak_role,
+            tiebreak_heat=self.tiebreak_heat_index,
+            tiebreak_subround=0
+        )
+        self.current_round.pairs = {
+            "pair_1": {"lead": self.pair_1[0].name, "follow": self.pair_1[1].name},
+            "pair_2": {"lead": self.pair_2[0].name, "follow": self.pair_2[1].name},
+        }
+
+    def judge_tiebreak(self, votes: list[tuple[str, int]]):
+        """Judge the current tiebreak subround for the active role. Disallow tie/no-contest votes.
+        Returns dict with winner and updated scoreboard."""
+        if not self.tiebreak_active or not self.tiebreak_role:
+            raise ValueError("No active tiebreak")
+        # Validate votes: guests and contestants can only vote 1 or 2
+        for voter, decision in votes:
+            if decision not in (1, 2):
+                raise ValueError("Tie and No Contest votes are not allowed in tiebreak")
+        # Compute scores
+        role = self.tiebreak_role
+        if role == 'lead':
+            c1 = self.pair_1[0]
+            c2 = self.pair_2[0]
+            vote_target = 'lead'
+        else:
+            c1 = self.pair_1[1]
+            c2 = self.pair_2[1]
+            vote_target = 'follow'
+        score1 = score2 = 0
+        for voter, decision in votes:
+            is_guest = voter in self.guest_judges
+            if decision == 1:
+                score1 += 2 if is_guest else 1
+            elif decision == 2:
+                score2 += 2 if is_guest else 1
+        # Ties on numeric score go to c1 by rule (no guest tie votes)
+        winner, loser = (c1, c2) if score1 >= score2 else (c2, c1)
+        # Update round vote storage and winner annotation for the judged role only
+        vote_dict = {v: d for (v, d) in votes}
+        if vote_target == 'lead':
+            self.current_round.lead_votes = vote_dict
+            self.current_round.lead_winner = winner.name
+        else:
+            self.current_round.follow_votes = vote_dict
+            self.current_round.follow_winner = winner.name
+        # Award tiebreak point to the competitor (ensure we increment only if winner is among competitors)
+        if winner.name in self.tiebreak_scores:
+            self.tiebreak_scores[winner.name] += 1
+        # Finalize this subround and decide whether we have a tiebreak champion
+        self.rounds.append(self.current_round)
+        self.round_num += 1
+        		                                                # Track consumption into this heat; declare heat finished after K pairs judged
+        K = self._tiebreak_rotation_size
+        self._tiebreak_pairs_in_current_heat += 2  # two pairs were judged in this subround
+        heat_finished = False
+        if self._tiebreak_pairs_in_current_heat >= K:
+            self._tiebreak_pairs_in_current_heat = 0
+            self.tiebreak_heat_index += 1
+            heat_finished = True
+        final_winner_name = None
+        if heat_finished:
+            # Check for unique leader
+            max_pts = max(self.tiebreak_scores.values())
+            leaders = [n for n, pts in self.tiebreak_scores.items() if pts == max_pts]
+            if len(leaders) == 1:
+                final_winner_name = leaders[0]
+                # Record and close tiebreak
+                if self.tiebreak_role == 'lead':
+                    self.tiebreak_winner_lead = final_winner_name
+                    self.last_lead_winner = final_winner_name
+                else:
+                    self.tiebreak_winner_follow = final_winner_name
+                    self.last_follow_winner = final_winner_name
+                self.tiebreak_active = False
+                self.tiebreak_role = None
+                self.tiebreak_competitors = []
+                self.tiebreak_partners = []
+                self._tiebreak_pair_buffer = []
+                # Leave scores for reporting purposes
+                return {
+                    "winner": winner.name,
+                    "tiebreak_scores": dict(self.tiebreak_scores),
+                    "tiebreak_finished": True,
+                    "final_winner": final_winner_name,
+                }
+        # Not finished yet: prepare next subround
+        self._prepare_next_tiebreak_subround()
+        return {
+            "winner": winner.name,
+            "tiebreak_scores": dict(self.tiebreak_scores),
+            "tiebreak_finished": False,
+            "next_pairs": self.get_current_pairs(),
+            "heat_index": self.tiebreak_heat_index,
+        }
+    
+    def get_current_pairs(self) -> dict:
+        """Helper to expose current pairing names."""
+        if not self.pair_1 or not self.pair_2:
+            return {}
+        return {
+            "pair_1": {"lead": self.pair_1[0].name, "follow": self.pair_1[1].name},
+            "pair_2": {"lead": self.pair_2[0].name, "follow": self.pair_2[1].name},
+        }
+    
     def start_round(self):
         """Start a new round by selecting pairs and contestant judges."""
         # Handle cases with insufficient contestants gracefully
@@ -321,6 +594,16 @@ class Game:
         if self.tie_follow_pair:
             current_follows = (self.pair_1[1], self.pair_2[1])
             self.tie_follow_pair = None
+
+        # Final fallback: ensure at least two leads and two follows available for selection
+        if len(self._leads) < 2:
+            for cand in (self.pair_1[0], self.pair_2[0]):
+                if cand not in self._leads:
+                    self._leads.append(cand)
+        if len(self._follows) < 2:
+            for cand in (self.pair_1[1], self.pair_2[1]):
+                if cand not in self._follows:
+                    self._follows.append(cand)
 
         # Handle lead selection based on game state
         if self.has_winning_lead and not self.has_winning_follow:

--- a/web/app.py
+++ b/web/app.py
@@ -146,6 +146,10 @@ def serialize_state(game: Game) -> dict:
                 'pairs': getattr(r, 'pairs', None),
                 'lead_winner': getattr(r, 'lead_winner', None),
                 'follow_winner': getattr(r, 'follow_winner', None),
+                'is_tiebreak': getattr(r, 'is_tiebreak', False),
+                'tiebreak_role': getattr(r, 'tiebreak_role', None),
+                'tiebreak_heat': getattr(r, 'tiebreak_heat', None),
+                'tiebreak_subround': getattr(r, 'tiebreak_subround', None),
             })
         cr = getattr(game, 'current_round', None)
         if cr and cr not in getattr(game, 'rounds', []):
@@ -154,11 +158,24 @@ def serialize_state(game: Game) -> dict:
                 'pairs': getattr(cr, 'pairs', None),
                 'lead_winner': getattr(cr, 'lead_winner', None),
                 'follow_winner': getattr(cr, 'follow_winner', None),
+                'is_tiebreak': getattr(cr, 'is_tiebreak', False),
+                'tiebreak_role': getattr(cr, 'tiebreak_role', None),
+                'tiebreak_heat': getattr(cr, 'tiebreak_heat', None),
+                'tiebreak_subround': getattr(cr, 'tiebreak_subround', None),
             })
         rounds_data = [rd for rd in rounds_data if rd.get('round_num') is not None]
         rounds_data.sort(key=lambda x: x['round_num'])
     except Exception:
         rounds_data = []
+
+    tiebreak_state = {
+        'active': getattr(game, 'tiebreak_active', False),
+        'role': getattr(game, 'tiebreak_role', None),
+        'competitors': [c.name for c in getattr(game, 'tiebreak_competitors', [])],
+        'partners': [c.name for c in getattr(game, 'tiebreak_partners', [])],
+        'scores': dict(getattr(game, 'tiebreak_scores', {})),
+        'heat_index': getattr(game, 'tiebreak_heat_index', 0),
+    }
 
     state = {
         'session_id': game.session_id,
@@ -194,6 +211,7 @@ def serialize_state(game: Game) -> dict:
             'leads': [c.name for c in getattr(game, 'initial_leads', [])],
             'follows': [c.name for c in getattr(game, 'initial_follows', [])],
         },
+        'tiebreak': tiebreak_state,
     }
     return state
 
@@ -471,7 +489,11 @@ def end_game():
                 'win_messages': r.win_messages,
                 'lead_winner': r.lead_winner,
                 'follow_winner': r.follow_winner,
-                'song_info': r.song_info if hasattr(r, 'song_info') else None
+                'song_info': r.song_info if hasattr(r, 'song_info') else None,
+                'is_tiebreak': getattr(r, 'is_tiebreak', False),
+                'tiebreak_role': getattr(r, 'tiebreak_role', None),
+                'tiebreak_heat': getattr(r, 'tiebreak_heat', None),
+                'tiebreak_subround': getattr(r, 'tiebreak_subround', None)
             }
             rounds_data.append(round_data)
     
@@ -489,7 +511,11 @@ def end_game():
                 'win_messages': game.current_round.win_messages,
                 'lead_winner': game.current_round.lead_winner,
                 'follow_winner': game.current_round.follow_winner,
-                'song_info': game.current_round.song_info if hasattr(game.current_round, 'song_info') else None
+                'song_info': game.current_round.song_info if hasattr(game.current_round, 'song_info') else None,
+                'is_tiebreak': getattr(game.current_round, 'is_tiebreak', False),
+                'tiebreak_role': getattr(game.current_round, 'tiebreak_role', None),
+                'tiebreak_heat': getattr(game.current_round, 'tiebreak_heat', None),
+                'tiebreak_subround': getattr(game.current_round, 'tiebreak_subround', None)
             }
             rounds_data.append(current_round_data)
     
@@ -1217,6 +1243,65 @@ def get_spotify_token():
         return jsonify(auth_response.json())
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+@app.route('/api/start_tiebreak', methods=['POST'])
+def start_tiebreak():
+    data = request.get_json() or {}
+    session_id = data.get('session_id')
+    role = data.get('role')  # 'lead' or 'follow'
+    competitors = data.get('competitors')  # optional explicit list
+    if not session_id or role not in ('lead', 'follow'):
+        return jsonify({'error': 'Missing session_id or invalid role'}), 400
+    game = repo.get(session_id)
+    if not game:
+        return jsonify({'error': 'Invalid session ID'}), 400
+    try:
+        resp = game.start_tiebreak(role, competitors)
+        return jsonify({'ok': True, 'tiebreak': resp})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+
+@app.route('/api/set_tiebreak_partners', methods=['POST'])
+def set_tiebreak_partners():
+    data = request.get_json() or {}
+    session_id = data.get('session_id')
+    assignments = data.get('assignments')  # list of [competitor, partner]
+    if not session_id or not isinstance(assignments, list) or not assignments:
+        return jsonify({'error': 'Missing session_id or assignments'}), 400
+    game = repo.get(session_id)
+    if not game:
+        return jsonify({'error': 'Invalid session ID'}), 400
+    try:
+        pairs = [(a[0], a[1]) for a in assignments]
+        state = game.set_tiebreak_partners(pairs)
+        return jsonify({'ok': True, 'state': state})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+
+@app.route('/api/tiebreak_state', methods=['GET'])
+def tiebreak_state():
+    session_id = request.args.get('session_id')
+    game = repo.get(session_id) if session_id else None
+    if not game:
+        return jsonify({'error': 'Game not found'}), 404
+    return jsonify(serialize_state(game).get('tiebreak', {}))
+
+@app.route('/api/judge_tiebreak', methods=['POST'])
+def judge_tiebreak():
+    data = request.get_json() or {}
+    session_id = data.get('session_id')
+    votes = data.get('votes', [])  # list of [judge, 1|2]
+    if not session_id or not votes:
+        return jsonify({'error': 'Missing session_id or votes'}), 400
+    game = repo.get(session_id)
+    if not game:
+        return jsonify({'error': 'Invalid session ID'}), 400
+    try:
+        vote_tuples = [(v[0], int(v[1])) for v in votes]
+        result = game.judge_tiebreak(vote_tuples)
+        return jsonify({'ok': True, **result})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
 
 if __name__ == '__main__':
     app.run(host=config.HOST, port=config.PORT, debug=config.DEBUG) 

--- a/web/index.html
+++ b/web/index.html
@@ -221,6 +221,25 @@
         <div id="results-screen" class="screen">
             <h2>Final Results</h2>
             
+            <div id="tiebreak-controls" class="tiebreak-section" style="display:none; margin-bottom: 16px;">
+                <h3>Tie-break Required</h3>
+                <div id="tiebreak-message" class="note"></div>
+                <div class="tiebreak-actions">
+                    <button id="start-tiebreak-lead" class="btn primary">Resolve Lead Tie</button>
+                    <button id="start-tiebreak-follow" class="btn primary">Resolve Follow Tie</button>
+                </div>
+                <div id="tiebreak-partner-selection" class="tiebreak-partner" style="display:none; margin-top: 12px;">
+                    <h4>Select Unique Partners</h4>
+                    <div id="tiebreak-partner-form"></div>
+                    <button id="submit-tiebreak-partners" class="btn primary" style="margin-top:8px;">Lock Partners</button>
+                </div>
+                <div id="tiebreak-live" class="tiebreak-live" style="display:none; margin-top: 12px;">
+                    <div id="tiebreak-status"></div>
+                    <div id="tiebreak-scoreboard" class="tiebreak-scoreboard"></div>
+                    <div id="tiebreak-judging" class="tiebreak-judging"></div>
+                </div>
+            </div>
+            
             <div class="battle-graphic-section">
                 <div class="battle-graphic">
                     <div class="graphic-column">

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1658,6 +1658,179 @@ async function downloadBattleData() {
     }
 }
 
+async function detectAndRenderTiesForResults(leads, follows) {
+    try {
+        // Determine ties at top for each role
+        const topLeadPts = leads.length ? Math.max(...leads.map(l => Number(l.points) || 0)) : 0;
+        const leadTied = leads.filter(l => (Number(l.points) || 0) === topLeadPts).map(l => l.name);
+        const topFollowPts = follows.length ? Math.max(...follows.map(f => Number(f.points) || 0)) : 0;
+        const followTied = follows.filter(f => (Number(f.points) || 0) === topFollowPts).map(f => f.name);
+        const tiebreakControls = document.getElementById('tiebreak-controls');
+        const tiebreakMessage = document.getElementById('tiebreak-message');
+        const startLeadBtn = document.getElementById('start-tiebreak-lead');
+        const startFollowBtn = document.getElementById('start-tiebreak-follow');
+        if (!tiebreakControls) return;
+        const showLead = leadTied.length > 1;
+        const showFollow = followTied.length > 1;
+        if (!showLead && !showFollow) {
+            tiebreakControls.style.display = 'none';
+            return;
+        }
+        tiebreakControls.style.display = '';
+        const msgs = [];
+        if (showLead) msgs.push(`Lead tie: ${leadTied.join(', ')}`);
+        if (showFollow) msgs.push(`Follow tie: ${followTied.join(', ')}`);
+        tiebreakMessage.textContent = msgs.join(' | ');
+        if (startLeadBtn) {
+            startLeadBtn.style.display = showLead ? '' : 'none';
+            startLeadBtn.onclick = () => beginTiebreakFlow('lead', leadTied);
+        }
+        if (startFollowBtn) {
+            startFollowBtn.style.display = showFollow ? '' : 'none';
+            startFollowBtn.onclick = () => beginTiebreakFlow('follow', followTied);
+        }
+    } catch (e) {
+        console.error('detectAndRenderTiesForResults failed:', e);
+    }
+}
+
+async function beginTiebreakFlow(role, competitors) {
+    try {
+        // Start tiebreak
+        const resp = await fetch('/api/start_tiebreak', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session_id: sessionId, role, competitors })
+        });
+        const data = await resp.json();
+        if (!resp.ok || data.error) throw new Error(data.error || 'start_tiebreak failed');
+        // Show partner selection UI
+        const partnerSel = document.getElementById('tiebreak-partner-selection');
+        const form = document.getElementById('tiebreak-partner-form');
+        const tbLive = document.getElementById('tiebreak-live');
+        if (partnerSel && form) {
+            partnerSel.style.display = '';
+            tbLive.style.display = 'none';
+            // Build partner selection lists from original pool
+            const state = await fetchCanonicalState();
+            const pool = role === 'lead' ? (state.initial_order?.follows || []) : (state.initial_order?.leads || []);
+            form.innerHTML = '';
+            competitors.forEach((name, idx) => {
+                const row = document.createElement('div');
+                row.className = 'tiebreak-row';
+                const label = document.createElement('label');
+                label.textContent = `${name} selects:`;
+                label.setAttribute('for', `tb-partner-${idx}`);
+                const select = document.createElement('select');
+                select.id = `tb-partner-${idx}`;
+                pool.forEach(p => {
+                    const opt = document.createElement('option'); opt.value = p; opt.textContent = p; select.appendChild(opt);
+                });
+                row.appendChild(label); row.appendChild(select);
+                form.appendChild(row);
+            });
+            const submitBtn = document.getElementById('submit-tiebreak-partners');
+            submitBtn.onclick = async () => {
+                // Collect and enforce uniqueness
+                const chosen = [];
+                const options = form.querySelectorAll('select');
+                options.forEach((sel, i) => { chosen.push(sel.value); });
+                const unique = new Set(chosen);
+                if (unique.size !== chosen.length) { alert('Partners must be unique.'); return; }
+                const assignments = competitors.map((c, i) => [c, chosen[i]]);
+                const resp2 = await fetch('/api/set_tiebreak_partners', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ session_id: sessionId, assignments })
+                });
+                const data2 = await resp2.json();
+                if (!resp2.ok || data2.error) { alert(data2.error || 'Failed to set partners'); return; }
+                partnerSel.style.display = 'none';
+                tbLive.style.display = '';
+                renderTiebreakLive(role);
+            };
+        }
+    } catch (e) {
+        alert(e.message || String(e));
+    }
+}
+
+async function renderTiebreakLive(role) {
+    const status = document.getElementById('tiebreak-status');
+    const board = document.getElementById('tiebreak-scoreboard');
+    const judgeDiv = document.getElementById('tiebreak-judging');
+    try {
+        const state = await fetch(`/api/tiebreak_state?session_id=${sessionId}`).then(r => r.json());
+        if (!state || !state.active) { status.textContent = 'Tiebreak finished or not active.'; return; }
+        status.textContent = `Tiebreak (${role}) – Heat ${Number(state.heat_index) + 1}`;
+        // Scoreboard
+        board.innerHTML = '';
+        const table = document.createElement('table'); table.className = 'results-table';
+        const thead = document.createElement('thead'); thead.innerHTML = '<tr><th>Competitor</th><th>TB Pts</th></tr>';
+        const tbody = document.createElement('tbody');
+        (state.competitors || []).forEach(name => {
+            const tr = document.createElement('tr');
+            const tdN = document.createElement('td'); tdN.textContent = name;
+            const tdP = document.createElement('td'); tdP.textContent = (state.scores && state.scores[name]) ? state.scores[name] : 0;
+            tr.appendChild(tdN); tr.appendChild(tdP); tbody.appendChild(tr);
+        });
+        table.appendChild(thead); table.appendChild(tbody); board.appendChild(table);
+        // Judging UI – reuse guest + contestant judges; only allow 1/2
+        judgeDiv.innerHTML = '';
+        const canon = await fetchCanonicalState();
+        const gj = (canon.round && canon.round.judges && canon.round.judges.guest) || [];
+        const cj = (canon.round && canon.round.judges && canon.round.judges.contestant) || [];
+        const allJ = [...gj, ...cj];
+        const pairs = canon.round?.pairs || null;
+        if (!pairs) return;
+        const voteCards = document.createElement('div'); voteCards.className = 'judges-container';
+        const votes = {};
+        const opt1Name = role === 'lead' ? pairs.pair_1.lead : pairs.pair_1.follow;
+        const opt2Name = role === 'lead' ? pairs.pair_2.lead : pairs.pair_2.follow;
+        allJ.forEach(j => {
+            const card = document.createElement('div'); card.className = 'judge-card';
+            const title = document.createElement('div'); title.className = 'judge-name'; title.textContent = j;
+            const opts = document.createElement('div'); opts.className = 'vote-options';
+            const b1 = document.createElement('button'); b1.className = 'vote-btn vote-option-1'; b1.textContent = opt1Name;
+            const b2 = document.createElement('button'); b2.className = 'vote-btn vote-option-2'; b2.textContent = opt2Name;
+            b1.onclick = () => { votes[j] = 1; b1.classList.add('selected'); b2.classList.remove('selected'); };
+            b2.onclick = () => { votes[j] = 2; b2.classList.add('selected'); b1.classList.remove('selected'); };
+            opts.appendChild(b1); opts.appendChild(b2);
+            card.appendChild(title); card.appendChild(opts); voteCards.appendChild(card);
+        });
+        judgeDiv.appendChild(voteCards);
+        const submit = document.createElement('button'); submit.className = 'btn primary'; submit.textContent = 'Submit Tiebreak Votes';
+        submit.onclick = async () => {
+            // Ensure all judges voted
+            const missing = allJ.filter(j => !votes[j]);
+            if (missing.length) { alert('All judges must vote.'); return; }
+            const payload = Object.entries(votes).map(([j, v]) => [j, v]);
+            const r = await fetch('/api/judge_tiebreak', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id: sessionId, votes: payload }) });
+            const d = await r.json();
+            if (!r.ok || d.error) { alert(d.error || 'Failed to judge tiebreak'); return; }
+            if (d.tiebreak_finished) {
+                status.textContent = `Tiebreak winner: ${d.final_winner}`;
+                await refreshCanonicalState();
+                // Hide tiebreak live once done
+                setTimeout(() => {
+                    const tbLive = document.getElementById('tiebreak-live'); if (tbLive) tbLive.style.display = 'none';
+                }, 1000);
+            } else {
+                await refreshCanonicalState();
+                renderTiebreakLive(role);
+            }
+        };
+        judgeDiv.appendChild(submit);
+    } catch (e) {
+        console.error('renderTiebreakLive failed:', e);
+    }
+}
+
+// Hook tie detection into displayResults
+const _displayResults_original = displayResults;
+displayResults = async function(data) {
+    await _displayResults_original(data);
+    try { await detectAndRenderTiesForResults(data.leads || [], data.follows || []); } catch (_) {}
+};
+
 // End game function
 function endGame() {
     // Disable voting buttons


### PR DESCRIPTION
Implement a rotation-based, sudden-death tie-breaker for battle results to resolve ties among top-scoring competitors in a given role.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ba93753-15de-4f75-a820-a5480aedbf8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ba93753-15de-4f75-a820-a5480aedbf8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

