### PR TITLE
Add ad hoc battle round

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -25,6 +25,7 @@ class Round:
         self.follow_winner = None  # Will store the name of the follow winner
         self.song_info = None  # Will store song information for this round
         self.session_id = session_id  # Store the session ID for this round
+        self.is_ad_hoc = False  # Marks an ad-hoc round that should not affect ordering
 
 
 class ContestantQueueProxy:
@@ -247,6 +248,126 @@ class Game:
                 "lead": self.pair_2[0].name,
                 "follow": self.pair_2[1].name
             }
+        }
+
+    def judge_combined_ad_hoc(self, lead_votes, follow_votes, song_info):
+        """Compute winners for an ad-hoc round and record it without mutating queues or flags.
+
+        - Uses current pairs and judges
+        - Applies the same scoring rules
+        - Does NOT change points, queues, winners, or round_num
+        - Appends an ad-hoc Round to history with a fractional round number for ordering
+        """
+        # Guard: need an ongoing round with pairs
+        if not self.current_round or not self.pair_1 or not self.pair_2:
+            return {
+                'error': 'No active round to base ad-hoc round on.'
+            }
+
+        # Prepare vote dicts
+        def to_vote_dict(votes_list):
+            d = {}
+            for voter, decision in votes_list:
+                d[voter] = decision
+            return d
+
+        lead_vote_dict = to_vote_dict(lead_votes)
+        follow_vote_dict = to_vote_dict(follow_votes)
+
+        # Contestant names
+        lead1_name = self.pair_1[0].name
+        lead2_name = self.pair_2[0].name
+        follow1_name = self.pair_1[1].name
+        follow2_name = self.pair_2[1].name
+
+        # Helper: compute winner label by vote dict
+        def compute_winner(vote_dict, is_lead):
+            # Guest votes array
+            guest_votes_only = [vote_dict.get(j, None) for j in self.guest_judges if j in vote_dict]
+            # Tie special: all guest votes are 3
+            if guest_votes_only and all(v == 3 for v in guest_votes_only):
+                c1 = lead1_name if is_lead else follow1_name
+                c2 = lead2_name if is_lead else follow2_name
+                return f"Tie between {c1} and {c2}"
+            # No contest special: all guest votes are 4
+            if guest_votes_only and all(v == 4 for v in guest_votes_only):
+                return "No Contest"
+            # Weighted scoring
+            s1 = 0
+            s2 = 0
+            for voter, decision in vote_dict.items():
+                is_guest = voter in self.guest_judges
+                weight = 2 if is_guest else 1
+                if decision == 1:
+                    s1 += weight
+                elif decision == 2:
+                    s2 += weight
+                elif decision == 3 and is_guest:
+                    s1 += 1
+                    s2 += 1
+            # Tie goes to contestant 1
+            return (lead1_name if is_lead else follow1_name) if s1 >= s2 else (lead2_name if is_lead else follow2_name)
+
+        lead_winner_label = compute_winner(lead_vote_dict, True)
+        follow_winner_label = compute_winner(follow_vote_dict, False)
+
+        # Build ad-hoc round snapshot
+        ad_hoc_round = Round(
+            round_num=self.round_num + 0.5,  # fractional so it sits between current and next
+            lead_votes=lead_vote_dict,
+            follow_votes=follow_vote_dict,
+            judges=self.guest_judges,
+            contestant_judges=[j.name for j in self.contestant_judges],
+            session_id=self.session_id
+        )
+        ad_hoc_round.is_ad_hoc = True
+        ad_hoc_round.pairs = {
+            "pair_1": {"lead": lead1_name, "follow": follow1_name},
+            "pair_2": {"lead": lead2_name, "follow": follow2_name},
+        }
+        ad_hoc_round.song_info = song_info or None
+        # Only set winners if not Tie/No Contest strings
+        if not isinstance(lead_winner_label, str) or (isinstance(lead_winner_label, str) and not lead_winner_label.startswith("Tie between") and lead_winner_label != "No Contest"):
+            ad_hoc_round.lead_winner = lead_winner_label
+        if not isinstance(follow_winner_label, str) or (isinstance(follow_winner_label, str) and not follow_winner_label.startswith("Tie between") and follow_winner_label != "No Contest"):
+            ad_hoc_round.follow_winner = follow_winner_label
+
+        # Append to history without mutating any game flow state
+        self.rounds.append(ad_hoc_round)
+
+        # Construct API response similar to /api/judge_combined for UI reuse
+        # Split guest vs contestant voters for transparency
+        def split_votes_for_winner(vote_dict, winner_label, c1_name, c2_name):
+            guest_voters = []
+            contestant_voters = []
+            for voter, decision in vote_dict.items():
+                is_guest = voter in self.guest_judges
+                voted_for = None
+                if decision == 1:
+                    voted_for = c1_name
+                elif decision == 2:
+                    voted_for = c2_name
+                elif decision == 3:
+                    # tie; counts toward both conceptually, but we won't list as for-winner
+                    voted_for = None
+                elif decision == 4:
+                    voted_for = None
+                if voted_for and winner_label == voted_for:
+                    (guest_voters if is_guest else contestant_voters).append(voter)
+            return guest_voters, contestant_voters
+
+        lead_gv, lead_cv = split_votes_for_winner(lead_vote_dict, lead_winner_label if isinstance(lead_winner_label, str) else lead_winner_label, lead1_name, lead2_name)
+        follow_gv, follow_cv = split_votes_for_winner(follow_vote_dict, follow_winner_label if isinstance(follow_winner_label, str) else follow_winner_label, follow1_name, follow2_name)
+
+        return {
+            'lead_winner': lead_winner_label,
+            'lead_guest_votes': lead_gv,
+            'lead_contestant_votes': lead_cv,
+            'follow_winner': follow_winner_label,
+            'follow_guest_votes': follow_gv,
+            'follow_contestant_votes': follow_cv,
+            'win_messages': [],
+            'game_finished': self.is_finished()
         }
 
     def get_contestant_judges(self):

--- a/web/app.py
+++ b/web/app.py
@@ -456,6 +456,27 @@ def judge_combined():
         'game_finished': game.is_finished()
     })
 
+@app.route('/api/judge_combined_ad_hoc', methods=['POST'])
+def judge_combined_ad_hoc():
+    """Process an ad-hoc round: determine winners and record the round without affecting order/queues."""
+    data = request.get_json()
+    session_id = data.get('session_id')
+    lead_votes = data.get('lead_votes', [])
+    follow_votes = data.get('follow_votes', [])
+    song_info = data.get('song_info', {})
+
+    if not session_id or not lead_votes or not follow_votes:
+        return jsonify({'error': 'Missing session_id, lead_votes, or follow_votes'}), 400
+
+    game = repo.get(session_id)
+    if not game:
+        return jsonify({'error': 'Invalid session ID'}), 400
+
+    # Delegate to game logic that performs no queue/ordering mutations
+    result = game.judge_combined_ad_hoc(lead_votes, follow_votes, song_info)
+
+    return jsonify(result)
+
 @app.route('/api/next_round', methods=['POST'])
 def next_round():
     data = request.get_json()

--- a/web/index.html
+++ b/web/index.html
@@ -195,6 +195,7 @@
                 
                 <div class="vote-submission">
                     <button id="submit-votes" class="btn primary">Submit All Votes</button>
+                    <button id="add-ad-hoc-round" class="btn secondary" style="margin-left: 8px;">Ad-hoc Round</button>
                 </div>
                 
                 <div id="voting-results" class="results hidden">

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -38,6 +38,7 @@ let leadWinnerPreview, followWinnerPreview, leadPreviewName, followPreviewName;
 let roundResultsSection, winMessages, nextRoundBtn, endBattleBtn;
 let leadsLeaderboard, followsLeaderboard;
 let backToHomeFromResultsBtn, downloadBattleDataBtn;
+let addAdHocRoundBtn;
 
 // Event Listeners
 document.addEventListener('DOMContentLoaded', () => {
@@ -115,6 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
     followsLeaderboard = document.getElementById('follows-leaderboard');
     backToHomeFromResultsBtn = document.getElementById('back-to-home-from-results');
     downloadBattleDataBtn = document.getElementById('download-battle-data');
+    addAdHocRoundBtn = document.getElementById('add-ad-hoc-round');
     
     // Check if elements exist
     console.log('Checking elements:');
@@ -168,6 +170,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Battle flow
     submitVotesBtn.addEventListener('click', submitCombinedVotes);
     nextRoundBtn.addEventListener('click', goToNextRound);
+    if (addAdHocRoundBtn) addAdHocRoundBtn.addEventListener('click', submitAdHocRound);
     endBattleBtn.addEventListener('click', endCompetition);
     
     // Results screen
@@ -1069,6 +1072,77 @@ async function submitCombinedVotes() {
         votingLocked.lead = false; // Unlock voting if there's an error
         votingLocked.follow = false;
         submitVotesBtn.disabled = false;
+    }
+}
+
+async function submitAdHocRound() {
+    // Build judge arrays from existing collected votes
+    const contestantJudgeElements = contestantJudgesList.querySelectorAll('.judge-item.contestant');
+    const contestantJudges = Array.from(contestantJudgeElements).map(el => el.textContent);
+    const allJudges = [...guestJudges, ...contestantJudges];
+
+    // Require full votes for both roles
+    const missingLeadVotes = allJudges.filter(judge => !leadVotes[judge]);
+    const missingFollowVotes = allJudges.filter(judge => !followVotes[judge]);
+    if (missingLeadVotes.length > 0 || missingFollowVotes.length > 0) {
+        const totalMissing = Math.max(missingLeadVotes.length, missingFollowVotes.length);
+        alert(`Waiting for votes from ${totalMissing} judge(s). Please ensure all judges have voted for both leads and follows.`);
+        return;
+    }
+
+    // Convert votes to array format
+    const leadVotesArray = Object.entries(leadVotes);
+    const followVotesArray = Object.entries(followVotes);
+
+    // Song info (reuse same extraction as combined submit)
+    const songInput = document.getElementById('song-input');
+    const songInfo = {};
+    if (playlistModeEnabled && currentRoundTrack && currentRoundTrack.id) {
+        songInfo.spotify_url = `https://open.spotify.com/track/${currentRoundTrack.id}`;
+        songInfo.title = currentRoundTrack.name || '';
+        songInfo.artist = currentRoundTrack.artists || '';
+    } else if (songInput && songInput.value) {
+        try {
+            const spotifyUrl = new URL(songInput.value);
+            if (spotifyUrl.hostname === 'open.spotify.com') {
+                songInfo.spotify_url = songInput.value;
+            }
+        } catch (_) {}
+    }
+
+    // Do not lock voting; ad-hoc should be lightweight
+    try {
+        const response = await fetch('/api/judge_combined_ad_hoc', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                session_id: sessionId,
+                lead_votes: leadVotesArray,
+                follow_votes: followVotesArray,
+                song_info: songInfo
+            })
+        });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data && data.error ? data.error : 'Ad-hoc round failed');
+
+        // Show winners inline, but do not change to next round
+        leadWinner.textContent = data.lead_winner;
+        leadGuestVotes.textContent = (data.lead_guest_votes || []).join(', ') || 'None';
+        leadContestantVotes.textContent = (data.lead_contestant_votes || []).join(', ') || 'None';
+        followWinner.textContent = data.follow_winner;
+        followGuestVotes.textContent = (data.follow_guest_votes || []).join(', ') || 'None';
+        followContestantVotes.textContent = (data.follow_contestant_votes || []).join(', ') || 'None';
+        votingResults.classList.remove('hidden');
+        roundResultsSection.classList.remove('hidden');
+
+        // Refresh live graphic to reflect round badges (ad-hoc is included in rounds history)
+        try {
+            const state = await fetchCanonicalState();
+            if (state) updateLiveGraphicFromState(state);
+        } catch (_) {}
+    } catch (e) {
+        console.error('Ad-hoc round error:', e);
+        alert(`Failed to submit ad-hoc round: ${e.message}`);
     }
 }
 


### PR DESCRIPTION
Add an ad-hoc round button and logic to allow judges to record a round's winners without altering the battle's participant order or advancing the main game.

---
<a href="https://cursor.com/background-agent?bcId=bc-5df1ca2c-12a2-4dbd-a27d-40146cea6515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5df1ca2c-12a2-4dbd-a27d-40146cea6515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

