### PR TITLE
Fix dark mode contrast for circled round numbers in battle graphic

### DIFF
--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -1296,6 +1296,10 @@ input[type="checkbox"] {
     border-color: var(--accent);
 }
 
+[data-color="dark"] .badge.win {
+    color: #fff;
+}
+
 /* ============================================================
    19. Toast Notifications
    ============================================================ */


### PR DESCRIPTION
In dark mode, winning round badges used accent purple (#7c3aed) text on a
near-transparent purple background, making the number hard to read. Override
color to white for dark mode so the round number is clearly legible.

https://claude.ai/code/session_01EtDAvWfXZDz2uX6uPM1iYS