### PR TITLE
feat: tie-break mode

### DIFF
--- a/game_logic.py
+++ b/game_logic.py
@@ -176,6 +176,8 @@ class Game:
         self.tiebreak_follow_needed = False
         self.tiebreak_leads_tied = []        # list of Contestant objects
         self.tiebreak_follows_tied = []      # list of Contestant objects
+        self.tiebreak_original_leads = []    # snapshot at tiebreak start (never narrowed)
+        self.tiebreak_original_follows = []  # snapshot at tiebreak start (never narrowed)
         self.tiebreak_sub_round = 0          # 0=setup, 1=sr1, 2=sr2, 3=voting
         self.tiebreak_sub_round_1_pairings = []  # list of (lead_name, follow_name)
         self.tiebreak_sub_round_2_pairings = []
@@ -906,6 +908,8 @@ class Game:
         self.tiebreak_sub_round = 0
         self.tiebreak_sub_round_1_pairings = []
         self.tiebreak_sub_round_2_pairings = []
+        self.tiebreak_original_leads = list(self.tiebreak_leads_tied)
+        self.tiebreak_original_follows = list(self.tiebreak_follows_tied)
         self.tiebreak_lead_winner = None
         self.tiebreak_follow_winner = None
 

--- a/game_logic.py
+++ b/game_logic.py
@@ -912,24 +912,46 @@ class Game:
     def set_tiebreak_partner_selections(self, lead_selections, follow_selections=None):
         """Record partner selections and compute sub-round pairings.
 
-        lead_selections: {lead_name: follow_name} for each tied lead.
-        follow_selections: {follow_name: lead_name} for each tied follow (only
-            used when follows are also tied; otherwise ignored).
+        lead_selections: {lead_name: follow_name} — tied leads pick follows.
+        follow_selections: {follow_name: lead_name} — tied follows pick leads.
 
-        Sub-round 1: each tied lead with their chosen follow.
-        Sub-round 2: follows rotated by 1 (direct swap for N=2, cyclic for N>2).
+        Either or both may be provided depending on which roles are tied.
+        SR1: each picker dances with their chosen partner.
+        SR2: for lead tiebreak the follows rotate; for follow tiebreak the leads rotate.
+        Pairings from both roles are merged (deduplicated) into a single display list.
         Sets tiebreak_sub_round to 1.
         """
-        tied_lead_names = [c.name for c in self.tiebreak_leads_tied]
+        sr1, sr2 = [], []
 
-        sr1 = [(lead, lead_selections[lead]) for lead in tied_lead_names if lead in lead_selections]
+        # Lead tiebreak: tied leads each pick a follow; SR2 rotates the follows.
+        if self.tiebreak_leads_tied and lead_selections:
+            tied_lead_names = [c.name for c in self.tiebreak_leads_tied]
+            lead_sr1 = [(lead, lead_selections[lead]) for lead in tied_lead_names if lead in lead_selections]
+            if lead_sr1:
+                leads_ord = [p[0] for p in lead_sr1]
+                follows_ord = [p[1] for p in lead_sr1]
+                rotated_f = follows_ord[1:] + follows_ord[:1]
+                sr1.extend(lead_sr1)
+                sr2.extend(zip(leads_ord, rotated_f))
+
+        # Follow tiebreak: tied follows each pick a lead; SR2 rotates the leads.
+        if self.tiebreak_follows_tied and follow_selections:
+            tied_follow_names = [c.name for c in self.tiebreak_follows_tied]
+            follow_sr1 = [
+                (follow_selections[follow], follow)
+                for follow in tied_follow_names if follow in follow_selections
+            ]
+            if follow_sr1:
+                leads_ord = [p[0] for p in follow_sr1]
+                follows_ord = [p[1] for p in follow_sr1]
+                rotated_l = leads_ord[1:] + leads_ord[:1]
+                existing_sr1 = set(sr1)
+                sr1.extend(p for p in follow_sr1 if p not in existing_sr1)
+                existing_sr2 = set(sr2)
+                sr2.extend(p for p in zip(rotated_l, follows_ord) if p not in existing_sr2)
+
         self.tiebreak_sub_round_1_pairings = sr1
-
-        leads_in_order = [p[0] for p in sr1]
-        follows_in_order = [p[1] for p in sr1]
-        rotated = follows_in_order[1:] + follows_in_order[:1]
-        self.tiebreak_sub_round_2_pairings = list(zip(leads_in_order, rotated))
-
+        self.tiebreak_sub_round_2_pairings = sr2
         self.tiebreak_sub_round = 1
 
     def advance_tiebreak_sub_round(self):
@@ -941,36 +963,55 @@ class Game:
     def judge_tiebreak(self, role, votes):
         """Resolve tie-break voting for one role.
 
-        votes: list of (voter_name, decision) where decision is 1 or 2 only.
+        votes: list of (voter_name, chosen_contestant_name).
         Guest judges count for 2 points, contestant judges for 1.
-        On equal scores the first contestant in the tied list wins.
-        Sets tiebreak_lead_winner or tiebreak_follow_winner.
-        Returns {'winner': name, 'loser': name, 'vote_tally': {name: score}}.
+        If the top score is shared, the tied list is narrowed to those contestants
+        and sub_round is reset to 0 so another round can be run.
+        Returns {'resolved': bool, 'winner': name | None,
+                 'still_tied': [name, ...] | None, 'vote_tally': {name: score}}.
         """
         tied = self.tiebreak_leads_tied if role == 'lead' else self.tiebreak_follows_tied
         if len(tied) < 2:
             return None
 
-        c1, c2 = tied[0], tied[1]
-        s1 = s2 = 0
-        for voter, decision in votes:
+        name_to_contestant = {c.name: c for c in tied}
+        scores = {c: 0 for c in tied}
+
+        for voter, chosen_name in votes:
+            if chosen_name not in name_to_contestant:
+                continue
             weight = 2 if voter in self.guest_judges else 1
-            if decision == 1:
-                s1 += weight
-            elif decision == 2:
-                s2 += weight
+            scores[name_to_contestant[chosen_name]] += weight
 
-        winner, loser = (c1, c2) if s1 >= s2 else (c2, c1)
+        max_score = max(scores[c] for c in tied)
+        top_scorers = [c for c in tied if scores[c] == max_score]
 
+        if len(top_scorers) == 1:
+            winner = top_scorers[0]
+            if role == 'lead':
+                self.tiebreak_lead_winner = winner
+            else:
+                self.tiebreak_follow_winner = winner
+            return {
+                'resolved': True,
+                'winner': winner.name,
+                'still_tied': None,
+                'vote_tally': {c.name: scores[c] for c in tied},
+            }
+
+        # Still tied — narrow the list and reset for another round
         if role == 'lead':
-            self.tiebreak_lead_winner = winner
+            self.tiebreak_leads_tied = top_scorers
         else:
-            self.tiebreak_follow_winner = winner
-
+            self.tiebreak_follows_tied = top_scorers
+        self.tiebreak_sub_round = 0
+        self.tiebreak_sub_round_1_pairings = []
+        self.tiebreak_sub_round_2_pairings = []
         return {
-            'winner': winner.name,
-            'loser': loser.name,
-            'vote_tally': {c1.name: s1, c2.name: s2},
+            'resolved': False,
+            'winner': None,
+            'still_tied': [c.name for c in top_scorers],
+            'vote_tally': {c.name: scores[c] for c in tied},
         }
 
     def finalize_tiebreak_results(self):

--- a/game_logic.py
+++ b/game_logic.py
@@ -170,6 +170,18 @@ class Game:
         self.tie_lead_pair = None
         self.tie_follow_pair = None
 
+        # Tie-break mode state
+        self.tiebreak_active = False
+        self.tiebreak_lead_needed = False
+        self.tiebreak_follow_needed = False
+        self.tiebreak_leads_tied = []        # list of Contestant objects
+        self.tiebreak_follows_tied = []      # list of Contestant objects
+        self.tiebreak_sub_round = 0          # 0=setup, 1=sr1, 2=sr2, 3=voting
+        self.tiebreak_sub_round_1_pairings = []  # list of (lead_name, follow_name)
+        self.tiebreak_sub_round_2_pairings = []
+        self.tiebreak_lead_winner = None     # Contestant object
+        self.tiebreak_follow_winner = None   # Contestant object
+
         # Initialize previous pairs tracking
         self.previous_pairs = {}
 
@@ -840,6 +852,145 @@ class Game:
         all_follows.sort(key=lambda c: c.points, reverse=True)
 
         return all_leads, all_follows
+
+    # ------------------------------------------------------------------
+    # Tie-break methods
+    # ------------------------------------------------------------------
+
+    def detect_tiebreak_needs(self):
+        """Check if a tie-break is needed for either role after ending early.
+
+        Skips a role if that role already has a threshold winner
+        (has_winning_lead / has_winning_follow is True).
+        Returns a dict describing which roles need a tie-break and who is tied.
+        """
+        lead_needed = False
+        tied_lead_names = []
+        lead_max = 0
+
+        if not self.has_winning_lead and self.initial_leads:
+            lead_max = max(c.points for c in self.initial_leads)
+            tied = [c for c in self.initial_leads if c.points == lead_max]
+            if len(tied) >= 2:
+                lead_needed = True
+                self.tiebreak_leads_tied = tied
+                tied_lead_names = [c.name for c in tied]
+
+        follow_needed = False
+        tied_follow_names = []
+        follow_max = 0
+
+        if not self.has_winning_follow and self.initial_follows:
+            follow_max = max(c.points for c in self.initial_follows)
+            tied = [c for c in self.initial_follows if c.points == follow_max]
+            if len(tied) >= 2:
+                follow_needed = True
+                self.tiebreak_follows_tied = tied
+                tied_follow_names = [c.name for c in tied]
+
+        self.tiebreak_lead_needed = lead_needed
+        self.tiebreak_follow_needed = follow_needed
+
+        return {
+            'lead_needed': lead_needed,
+            'follow_needed': follow_needed,
+            'tied_leads': tied_lead_names,
+            'tied_follows': tied_follow_names,
+            'lead_max_points': lead_max,
+            'follow_max_points': follow_max,
+        }
+
+    def start_tiebreak(self):
+        """Enter tie-break mode without finishing the game yet."""
+        self.tiebreak_active = True
+        self.tiebreak_sub_round = 0
+        self.tiebreak_sub_round_1_pairings = []
+        self.tiebreak_sub_round_2_pairings = []
+        self.tiebreak_lead_winner = None
+        self.tiebreak_follow_winner = None
+
+    def set_tiebreak_partner_selections(self, lead_selections, follow_selections=None):
+        """Record partner selections and compute sub-round pairings.
+
+        lead_selections: {lead_name: follow_name} for each tied lead.
+        follow_selections: {follow_name: lead_name} for each tied follow (only
+            used when follows are also tied; otherwise ignored).
+
+        Sub-round 1: each tied lead with their chosen follow.
+        Sub-round 2: follows rotated by 1 (direct swap for N=2, cyclic for N>2).
+        Sets tiebreak_sub_round to 1.
+        """
+        tied_lead_names = [c.name for c in self.tiebreak_leads_tied]
+
+        sr1 = [(lead, lead_selections[lead]) for lead in tied_lead_names if lead in lead_selections]
+        self.tiebreak_sub_round_1_pairings = sr1
+
+        leads_in_order = [p[0] for p in sr1]
+        follows_in_order = [p[1] for p in sr1]
+        rotated = follows_in_order[1:] + follows_in_order[:1]
+        self.tiebreak_sub_round_2_pairings = list(zip(leads_in_order, rotated))
+
+        self.tiebreak_sub_round = 1
+
+    def advance_tiebreak_sub_round(self):
+        """Move to the next tie-break phase (1→2→3). Returns the new value."""
+        if self.tiebreak_sub_round < 3:
+            self.tiebreak_sub_round += 1
+        return self.tiebreak_sub_round
+
+    def judge_tiebreak(self, role, votes):
+        """Resolve tie-break voting for one role.
+
+        votes: list of (voter_name, decision) where decision is 1 or 2 only.
+        Guest judges count for 2 points, contestant judges for 1.
+        On equal scores the first contestant in the tied list wins.
+        Sets tiebreak_lead_winner or tiebreak_follow_winner.
+        Returns {'winner': name, 'loser': name, 'vote_tally': {name: score}}.
+        """
+        tied = self.tiebreak_leads_tied if role == 'lead' else self.tiebreak_follows_tied
+        if len(tied) < 2:
+            return None
+
+        c1, c2 = tied[0], tied[1]
+        s1 = s2 = 0
+        for voter, decision in votes:
+            weight = 2 if voter in self.guest_judges else 1
+            if decision == 1:
+                s1 += weight
+            elif decision == 2:
+                s2 += weight
+
+        winner, loser = (c1, c2) if s1 >= s2 else (c2, c1)
+
+        if role == 'lead':
+            self.tiebreak_lead_winner = winner
+        else:
+            self.tiebreak_follow_winner = winner
+
+        return {
+            'winner': winner.name,
+            'loser': loser.name,
+            'vote_tally': {c1.name: s1, c2.name: s2},
+        }
+
+    def finalize_tiebreak_results(self):
+        """Promote tie-break winners to overall winners and mark the game finished.
+
+        Awards +1 point to each tie-break winner so they rank above the
+        tied contestants they beat in the final standings.
+        """
+        if self.tiebreak_lead_needed and self.tiebreak_lead_winner:
+            self.tiebreak_lead_winner.points += 1
+            self.has_winning_lead = True
+            self.winning_lead = self.tiebreak_lead_winner
+
+        if self.tiebreak_follow_needed and self.tiebreak_follow_winner:
+            self.tiebreak_follow_winner.points += 1
+            self.has_winning_follow = True
+            self.winning_follow = self.tiebreak_follow_winner
+
+        self.tiebreak_active = False
+        self.state = 1
 
     def debug_state(self):
         """Print the current state of the game for debugging."""

--- a/run_complete_test_suite.py
+++ b/run_complete_test_suite.py
@@ -21,6 +21,11 @@ import traceback
 from battle_rules_test_suite import BattleRulesTestSuite, StressTestSuite, BattleRulesValidator
 from voting_rules_tests import VotingRulesTestSuite
 from pairing_rules_tests import PairingRulesTestSuite
+from tiebreak_tests import (
+    TestDetectTiebreakNeeds, TestStartTiebreak, TestPartnerSelections,
+    TestAdvanceTiebreakSubRound, TestJudgeTiebreak, TestFinalizeTiebreakResults,
+    TestEndToEndTiebreakFlow,
+)
 from game_logic import Game
 
 
@@ -44,6 +49,13 @@ class TestSuiteRunner:
             ("Voting Rules", VotingRulesTestSuite),
             ("Pairing Rules", PairingRulesTestSuite),
             ("Stress Tests", StressTestSuite),
+            ("Tie-Break: Detection", TestDetectTiebreakNeeds),
+            ("Tie-Break: Start", TestStartTiebreak),
+            ("Tie-Break: Partner Selections", TestPartnerSelections),
+            ("Tie-Break: Sub-Round Advance", TestAdvanceTiebreakSubRound),
+            ("Tie-Break: Judge Voting", TestJudgeTiebreak),
+            ("Tie-Break: Finalize", TestFinalizeTiebreakResults),
+            ("Tie-Break: End-to-End", TestEndToEndTiebreakFlow),
         ]
 
         print("=" * 60)

--- a/tiebreak_tests.py
+++ b/tiebreak_tests.py
@@ -1,0 +1,471 @@
+import unittest
+from game_logic import Game, Contestant
+
+
+def make_game(leads=None, follows=None, judges=None, points_to_win=7):
+    leads = leads or ["Lead1", "Lead2", "Lead3", "Lead4"]
+    follows = follows or ["Follow1", "Follow2", "Follow3", "Follow4"]
+    judges = judges or ["Judge1", "Judge2"]
+    return Game(leads, follows, judges, points_to_win=points_to_win)
+
+
+def set_points(game, lead_pts: dict, follow_pts: dict):
+    """Set point totals directly on contestant objects."""
+    for c in game.initial_leads:
+        if c.name in lead_pts:
+            c.points = lead_pts[c.name]
+    for c in game.initial_follows:
+        if c.name in follow_pts:
+            c.points = follow_pts[c.name]
+
+
+class TestDetectTiebreakNeeds(unittest.TestCase):
+
+    def test_no_tiebreak_when_clear_leader(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 1, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 3, "Follow2": 1, "Follow3": 0, "Follow4": 0})
+        result = game.detect_tiebreak_needs()
+        self.assertFalse(result["lead_needed"])
+        self.assertFalse(result["follow_needed"])
+
+    def test_lead_tiebreak_detected(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 1, "Lead4": 0},
+                         {"Follow1": 3, "Follow2": 1, "Follow3": 0, "Follow4": 0})
+        result = game.detect_tiebreak_needs()
+        self.assertTrue(result["lead_needed"])
+        self.assertFalse(result["follow_needed"])
+        self.assertCountEqual(result["tied_leads"], ["Lead1", "Lead2"])
+        self.assertEqual(result["lead_max_points"], 3)
+
+    def test_follow_tiebreak_detected(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 1, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 2, "Follow2": 2, "Follow3": 2, "Follow4": 0})
+        result = game.detect_tiebreak_needs()
+        self.assertFalse(result["lead_needed"])
+        self.assertTrue(result["follow_needed"])
+        self.assertCountEqual(result["tied_follows"], ["Follow1", "Follow2", "Follow3"])
+
+    def test_both_tiebreaks_detected(self):
+        game = make_game()
+        set_points(game, {"Lead1": 2, "Lead2": 2, "Lead3": 1, "Lead4": 0},
+                         {"Follow1": 2, "Follow2": 2, "Follow3": 0, "Follow4": 0})
+        result = game.detect_tiebreak_needs()
+        self.assertTrue(result["lead_needed"])
+        self.assertTrue(result["follow_needed"])
+
+    def test_skips_role_with_threshold_winner(self):
+        game = make_game()
+        set_points(game, {"Lead1": 7, "Lead2": 7, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 2, "Follow2": 2, "Follow3": 0, "Follow4": 0})
+        # Simulate lead already having a winner via threshold
+        game.has_winning_lead = True
+        result = game.detect_tiebreak_needs()
+        self.assertFalse(result["lead_needed"])
+        self.assertTrue(result["follow_needed"])
+
+    def test_three_way_lead_tie(self):
+        game = make_game()
+        set_points(game, {"Lead1": 4, "Lead2": 4, "Lead3": 4, "Lead4": 1},
+                         {"Follow1": 1, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        result = game.detect_tiebreak_needs()
+        self.assertTrue(result["lead_needed"])
+        self.assertCountEqual(result["tied_leads"], ["Lead1", "Lead2", "Lead3"])
+
+
+class TestStartTiebreak(unittest.TestCase):
+
+    def test_start_tiebreak_sets_state(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 1, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        self.assertTrue(game.tiebreak_active)
+        self.assertEqual(game.tiebreak_sub_round, 0)
+        self.assertIsNone(game.tiebreak_lead_winner)
+        self.assertIsNone(game.tiebreak_follow_winner)
+        self.assertEqual(game.tiebreak_sub_round_1_pairings, [])
+        self.assertEqual(game.tiebreak_sub_round_2_pairings, [])
+
+
+class TestPartnerSelections(unittest.TestCase):
+
+    def _game_with_lead_tie(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 1, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        return game
+
+    def _game_with_follow_tie(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 1, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 2, "Follow2": 2, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        return game
+
+    def _game_with_both_tied(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 2, "Follow2": 2, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        return game
+
+    def test_lead_only_sr1_pairings(self):
+        game = self._game_with_lead_tie()
+        game.set_tiebreak_partner_selections(
+            {"Lead1": "Follow1", "Lead2": "Follow2"}, {}
+        )
+        self.assertEqual(game.tiebreak_sub_round, 1)
+        self.assertIn(("Lead1", "Follow1"), game.tiebreak_sub_round_1_pairings)
+        self.assertIn(("Lead2", "Follow2"), game.tiebreak_sub_round_1_pairings)
+
+    def test_lead_only_sr2_rotates_follows(self):
+        game = self._game_with_lead_tie()
+        game.set_tiebreak_partner_selections(
+            {"Lead1": "Follow1", "Lead2": "Follow2"}, {}
+        )
+        sr2 = game.tiebreak_sub_round_2_pairings
+        # Follows should be swapped: Lead1→Follow2, Lead2→Follow1
+        self.assertIn(("Lead1", "Follow2"), sr2)
+        self.assertIn(("Lead2", "Follow1"), sr2)
+
+    def test_follow_only_sr1_pairings(self):
+        game = self._game_with_follow_tie()
+        game.set_tiebreak_partner_selections(
+            {}, {"Follow1": "Lead1", "Follow2": "Lead2"}
+        )
+        self.assertEqual(game.tiebreak_sub_round, 1)
+        self.assertIn(("Lead1", "Follow1"), game.tiebreak_sub_round_1_pairings)
+        self.assertIn(("Lead2", "Follow2"), game.tiebreak_sub_round_1_pairings)
+
+    def test_follow_only_sr2_rotates_leads(self):
+        game = self._game_with_follow_tie()
+        game.set_tiebreak_partner_selections(
+            {}, {"Follow1": "Lead1", "Follow2": "Lead2"}
+        )
+        sr2 = game.tiebreak_sub_round_2_pairings
+        # Leads should rotate: Follow1→Lead2, Follow2→Lead1
+        self.assertIn(("Lead2", "Follow1"), sr2)
+        self.assertIn(("Lead1", "Follow2"), sr2)
+
+    def test_both_tied_combined_pairings(self):
+        game = self._game_with_both_tied()
+        game.set_tiebreak_partner_selections(
+            {"Lead1": "Follow3", "Lead2": "Follow4"},
+            {"Follow1": "Lead3", "Follow2": "Lead4"}
+        )
+        sr1 = game.tiebreak_sub_round_1_pairings
+        # All 4 pairings should be present (no overlaps in this case)
+        self.assertIn(("Lead1", "Follow3"), sr1)
+        self.assertIn(("Lead2", "Follow4"), sr1)
+        self.assertIn(("Lead3", "Follow1"), sr1)
+        self.assertIn(("Lead4", "Follow2"), sr1)
+
+    def test_deduplication_when_pairs_overlap(self):
+        game = self._game_with_both_tied()
+        # Lead1 picks Follow1 and Follow1 picks Lead1 → same pair
+        game.set_tiebreak_partner_selections(
+            {"Lead1": "Follow1", "Lead2": "Follow2"},
+            {"Follow1": "Lead1", "Follow2": "Lead2"}
+        )
+        sr1 = game.tiebreak_sub_round_1_pairings
+        # (Lead1, Follow1) should only appear once
+        self.assertEqual(sr1.count(("Lead1", "Follow1")), 1)
+        self.assertEqual(sr1.count(("Lead2", "Follow2")), 1)
+
+    def test_three_way_tie_cyclic_rotation(self):
+        game = make_game(leads=["L1", "L2", "L3", "L4"],
+                         follows=["F1", "F2", "F3", "F4"])
+        set_points(game, {"L1": 3, "L2": 3, "L3": 3, "L4": 0},
+                         {"F1": 1, "F2": 0, "F3": 0, "F4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        game.set_tiebreak_partner_selections(
+            {"L1": "F1", "L2": "F2", "L3": "F3"}, {}
+        )
+        sr1 = game.tiebreak_sub_round_1_pairings
+        sr2 = game.tiebreak_sub_round_2_pairings
+        self.assertEqual(len(sr1), 3)
+        # SR2: follows rotate cyclically [F1,F2,F3] → [F2,F3,F1]
+        self.assertIn(("L1", "F2"), sr2)
+        self.assertIn(("L2", "F3"), sr2)
+        self.assertIn(("L3", "F1"), sr2)
+
+
+class TestAdvanceTiebreakSubRound(unittest.TestCase):
+
+    def test_advance_increments(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 0, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        game.set_tiebreak_partner_selections({"Lead1": "Follow1", "Lead2": "Follow2"}, {})
+        self.assertEqual(game.advance_tiebreak_sub_round(), 2)
+        self.assertEqual(game.advance_tiebreak_sub_round(), 3)
+
+    def test_advance_caps_at_3(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 0, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        game.tiebreak_sub_round = 3
+        result = game.advance_tiebreak_sub_round()
+        self.assertEqual(result, 3)
+
+
+class TestJudgeTiebreak(unittest.TestCase):
+
+    def _setup(self, lead_tie=True, follow_tie=False):
+        game = make_game()
+        lead_pts = {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0}
+        follow_pts = {"Follow1": 2 if follow_tie else 3,
+                      "Follow2": 2 if follow_tie else 1,
+                      "Follow3": 0, "Follow4": 0}
+        if not lead_tie:
+            lead_pts["Lead1"] = 4
+        set_points(game, lead_pts, follow_pts)
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        return game
+
+    def test_clear_winner_resolved(self):
+        game = self._setup(lead_tie=True)
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead1"),
+            ("Judge2", "Lead1"),
+        ])
+        self.assertTrue(result["resolved"])
+        self.assertEqual(result["winner"], "Lead1")
+        self.assertIsNotNone(game.tiebreak_lead_winner)
+        self.assertEqual(game.tiebreak_lead_winner.name, "Lead1")
+
+    def test_tied_vote_not_resolved(self):
+        game = self._setup(lead_tie=True)
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead1"),
+            ("Judge2", "Lead2"),
+        ])
+        self.assertFalse(result["resolved"])
+        self.assertIsNone(result["winner"])
+        self.assertCountEqual(result["still_tied"], ["Lead1", "Lead2"])
+        self.assertIsNone(game.tiebreak_lead_winner)
+
+    def test_tied_vote_resets_sub_round(self):
+        game = self._setup(lead_tie=True)
+        game.tiebreak_sub_round = 3
+        game.judge_tiebreak("lead", [("Judge1", "Lead1"), ("Judge2", "Lead2")])
+        self.assertEqual(game.tiebreak_sub_round, 0)
+        self.assertEqual(game.tiebreak_sub_round_1_pairings, [])
+
+    def test_tied_vote_narrows_tied_list(self):
+        """Three-way tie: vote narrows to two still-tied contestants."""
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 3, "Lead4": 0},
+                         {"Follow1": 1, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        # Lead1 and Lead2 each get 1 vote, Lead3 gets 0
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead1"),
+            ("Judge2", "Lead2"),
+        ])
+        self.assertFalse(result["resolved"])
+        self.assertCountEqual(result["still_tied"], ["Lead1", "Lead2"])
+        # Lead3 dropped from tied list
+        self.assertEqual(len(game.tiebreak_leads_tied), 2)
+
+    def test_guest_judge_weight(self):
+        """Guest judges count 2 pts, contestant judges 1 pt."""
+        game = self._setup(lead_tie=True)
+        contestant_judge = game.contestant_judges[0].name if game.contestant_judges else "Lead3"
+        # Judge1 (guest, 2pts) votes Lead2; contestant judge (1pt) votes Lead1
+        # Lead1: 1pt, Lead2: 2pt → Lead2 wins
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead2"),
+            (contestant_judge, "Lead1"),
+        ])
+        self.assertTrue(result["resolved"])
+        self.assertEqual(result["winner"], "Lead2")
+
+    def test_follow_tiebreak(self):
+        game = self._setup(lead_tie=False, follow_tie=True)
+        result = game.judge_tiebreak("follow", [
+            ("Judge1", "Follow1"),
+            ("Judge2", "Follow1"),
+        ])
+        self.assertTrue(result["resolved"])
+        self.assertEqual(result["winner"], "Follow1")
+        self.assertEqual(game.tiebreak_follow_winner.name, "Follow1")
+
+    def test_vote_tally_returned(self):
+        game = self._setup(lead_tie=True)
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead1"),
+            ("Judge2", "Lead2"),
+        ])
+        self.assertIn("Lead1", result["vote_tally"])
+        self.assertIn("Lead2", result["vote_tally"])
+
+    def test_unknown_contestant_name_ignored(self):
+        game = self._setup(lead_tie=True)
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead1"),
+            ("Judge2", "NotARealLead"),
+        ])
+        # Only Lead1 got a valid vote → Lead1 wins
+        self.assertTrue(result["resolved"])
+        self.assertEqual(result["winner"], "Lead1")
+
+
+class TestFinalizeTiebreakResults(unittest.TestCase):
+
+    def test_finalize_promotes_winners(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 2, "Follow2": 2, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        # Manually resolve both roles
+        game.judge_tiebreak("lead", [("Judge1", "Lead1"), ("Judge2", "Lead1")])
+        game.judge_tiebreak("follow", [("Judge1", "Follow1"), ("Judge2", "Follow1")])
+        game.finalize_tiebreak_results()
+        self.assertTrue(game.has_winning_lead)
+        self.assertTrue(game.has_winning_follow)
+        self.assertEqual(game.winning_lead.name, "Lead1")
+        self.assertEqual(game.winning_follow.name, "Follow1")
+        self.assertEqual(game.state, 1)
+
+    def test_finalize_awards_bonus_point(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 1, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        game.judge_tiebreak("lead", [("Judge1", "Lead1"), ("Judge2", "Lead1")])
+        points_before = game.tiebreak_lead_winner.points
+        game.finalize_tiebreak_results()
+        self.assertEqual(game.winning_lead.points, points_before + 1)
+
+    def test_finalize_only_promotes_needed_roles(self):
+        """If only one role needed a tiebreak, only that role gets promoted."""
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 1, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        game.judge_tiebreak("lead", [("Judge1", "Lead1"), ("Judge2", "Lead1")])
+        game.finalize_tiebreak_results()
+        self.assertTrue(game.has_winning_lead)
+        self.assertFalse(game.has_winning_follow)
+
+
+class TestEndToEndTiebreakFlow(unittest.TestCase):
+
+    def test_full_lead_only_tiebreak(self):
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 1, "Lead4": 0},
+                         {"Follow1": 4, "Follow2": 1, "Follow3": 0, "Follow4": 0})
+
+        info = game.detect_tiebreak_needs()
+        self.assertTrue(info["lead_needed"])
+        self.assertFalse(info["follow_needed"])
+
+        game.start_tiebreak()
+        game.set_tiebreak_partner_selections(
+            {"Lead1": "Follow1", "Lead2": "Follow2"}, {}
+        )
+        self.assertEqual(len(game.tiebreak_sub_round_1_pairings), 2)
+
+        game.advance_tiebreak_sub_round()  # → 2
+        game.advance_tiebreak_sub_round()  # → 3
+
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead1"),
+            ("Judge2", "Lead1"),
+        ])
+        self.assertTrue(result["resolved"])
+
+        game.finalize_tiebreak_results()
+        self.assertEqual(game.winning_lead.name, "Lead1")
+        self.assertEqual(game.state, 1)
+
+    def test_recursive_tiebreak_until_winner(self):
+        """Two tied leads, vote ties, second round resolves it."""
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 0, "Lead4": 0},
+                         {"Follow1": 1, "Follow2": 0, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        game.set_tiebreak_partner_selections({"Lead1": "Follow1", "Lead2": "Follow2"}, {})
+        game.advance_tiebreak_sub_round()
+        game.advance_tiebreak_sub_round()
+
+        # Round 1 vote: tie
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead1"),
+            ("Judge2", "Lead2"),
+        ])
+        self.assertFalse(result["resolved"])
+        self.assertEqual(game.tiebreak_sub_round, 0)
+
+        # Round 2: new partner selections → another set of sub-rounds
+        game.set_tiebreak_partner_selections({"Lead1": "Follow3", "Lead2": "Follow4"}, {})
+        game.advance_tiebreak_sub_round()
+        game.advance_tiebreak_sub_round()
+
+        # Round 2 vote: clear winner
+        result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead2"),
+            ("Judge2", "Lead2"),
+        ])
+        self.assertTrue(result["resolved"])
+        self.assertEqual(result["winner"], "Lead2")
+
+        game.finalize_tiebreak_results()
+        self.assertEqual(game.winning_lead.name, "Lead2")
+        self.assertEqual(game.state, 1)
+
+    def test_asymmetric_both_roles_tiebreak(self):
+        """3 leads tied, 2 follows tied — each role resolves independently."""
+        game = make_game()
+        set_points(game, {"Lead1": 3, "Lead2": 3, "Lead3": 3, "Lead4": 0},
+                         {"Follow1": 2, "Follow2": 2, "Follow3": 0, "Follow4": 0})
+        game.detect_tiebreak_needs()
+        game.start_tiebreak()
+        game.set_tiebreak_partner_selections(
+            {"Lead1": "Follow1", "Lead2": "Follow2", "Lead3": "Follow3"},
+            {"Follow1": "Lead4", "Follow2": "Lead3"}
+        )
+        # SR1 has lead pairings + follow pairings (minus any overlaps)
+        sr1 = game.tiebreak_sub_round_1_pairings
+        self.assertGreaterEqual(len(sr1), 3)
+
+        game.advance_tiebreak_sub_round()
+        game.advance_tiebreak_sub_round()
+
+        lead_result = game.judge_tiebreak("lead", [
+            ("Judge1", "Lead1"), ("Judge2", "Lead1"),
+        ])
+        follow_result = game.judge_tiebreak("follow", [
+            ("Judge1", "Follow2"), ("Judge2", "Follow2"),
+        ])
+        self.assertTrue(lead_result["resolved"])
+        self.assertTrue(follow_result["resolved"])
+
+        game.finalize_tiebreak_results()
+        self.assertEqual(game.winning_lead.name, "Lead1")
+        self.assertEqual(game.winning_follow.name, "Follow2")
+        self.assertEqual(game.state, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/web/app.py
+++ b/web/app.py
@@ -836,6 +836,25 @@ def _format_end_game_results(game, session_id):
             })
     rounds_data.sort(key=lambda x: x["round_num"])
 
+    # When a tiebreak was resolved, replace the incomplete pre-tiebreak round entry
+    # with a synthetic entry listing the original tiebreak participants so the battle
+    # graphic badges land on the right people.
+    if (game.tiebreak_lead_winner or game.tiebreak_follow_winner) and game.current_round:
+        last_round_num = game.current_round.round_num
+        rounds_data = [rd for rd in rounds_data if rd.get("round_num") != last_round_num]
+        rounds_data.append({
+            "round_num": last_round_num,
+            "tiebreak": True,
+            "tiebreak_leads": [c.name for c in game.tiebreak_original_leads],
+            "tiebreak_follows": [c.name for c in game.tiebreak_original_follows],
+            "lead_winner": game.tiebreak_lead_winner.name if game.tiebreak_lead_winner else None,
+            "follow_winner": game.tiebreak_follow_winner.name if game.tiebreak_follow_winner else None,
+            "pairs": None, "lead_votes": None, "follow_votes": None,
+            "judges": None, "contestant_judges": None,
+            "win_messages": None, "song_info": None,
+        })
+        rounds_data.sort(key=lambda x: x["round_num"])
+
     return {
         "session_id": session_id,
         "leads": lead_results,

--- a/web/app.py
+++ b/web/app.py
@@ -752,96 +752,174 @@ def end_game():
     if not game:
         return jsonify({"error": "Invalid session ID"}), 400
 
-    # Mark the game as finished so display mode polling detects it
+    # Check for tie-break before marking the game finished
+    tiebreak_info = game.detect_tiebreak_needs()
+    if tiebreak_info['lead_needed'] or tiebreak_info['follow_needed']:
+        game.start_tiebreak()
+        repo.save(session_id, game)
+        judges = getattr(game.current_round, 'judges', {}) if game.current_round else {}
+        return jsonify({
+            'tiebreak_required': True,
+            'lead_needed': tiebreak_info['lead_needed'],
+            'follow_needed': tiebreak_info['follow_needed'],
+            'tied_leads': tiebreak_info['tied_leads'],
+            'tied_follows': tiebreak_info['tied_follows'],
+            'lead_max_points': tiebreak_info['lead_max_points'],
+            'follow_max_points': tiebreak_info['follow_max_points'],
+            'all_leads': [c.name for c in game.initial_leads],
+            'all_follows': [c.name for c in game.initial_follows],
+            'guest_judges': judges.get('guest', []),
+            'contestant_judges': judges.get('contestant', []),
+        })
+
+    # No tie-break needed — mark the game as finished and return results
     game.state = 1
     repo.save(session_id, game)
+    return jsonify(_format_end_game_results(game, session_id))
 
+
+def _format_end_game_results(game, session_id):
+    """Shared results-formatting logic used by end_game and tiebreak/finalize."""
     leads, follows = game.finalize_results()
 
-    # Format the results - include all leads
-    lead_results = []
-    # Get all leads from initial order to ensure we include everyone
     all_leads = [lead.name for lead in game.initial_leads]
-    # Create a dictionary of lead points for easy lookup
     lead_points = {lead.name: lead.points for lead in leads}
-
-    # Sort leads by points (descending) and then by name (ascending) for consistent ordering
     sorted_leads = sorted(all_leads, key=lambda x: (-lead_points.get(x, 0), x))
-
-    for idx, lead_name in enumerate(sorted_leads):
-        points = lead_points.get(lead_name, 0)
+    lead_results = []
+    for idx, name in enumerate(sorted_leads):
         medal = ["🥇", "🥈", "🥉"][idx] if idx < 3 else ""
-        is_winner = hasattr(game, "last_lead_winner") and game.last_lead_winner == lead_name
-        lead_results.append({"name": lead_name, "points": points, "medal": medal, "is_winner": is_winner})
+        is_winner = game.winning_lead and game.winning_lead.name == name
+        lead_results.append({"name": name, "points": lead_points.get(name, 0), "medal": medal, "is_winner": is_winner})
 
-    # Format the results - include all follows
-    follow_results = []
-    # Get all follows from initial order to ensure we include everyone
     all_follows = [follow.name for follow in game.initial_follows]
-    # Create a dictionary of follow points for easy lookup
     follow_points = {follow.name: follow.points for follow in follows}
-
-    # Sort follows by points (descending) and then by name (ascending) for consistent ordering
     sorted_follows = sorted(all_follows, key=lambda x: (-follow_points.get(x, 0), x))
-
-    for idx, follow_name in enumerate(sorted_follows):
-        points = follow_points.get(follow_name, 0)
+    follow_results = []
+    for idx, name in enumerate(sorted_follows):
         medal = ["🥇", "🥈", "🥉"][idx] if idx < 3 else ""
-        is_winner = hasattr(game, "last_follow_winner") and game.last_follow_winner == follow_name
-        follow_results.append({"name": follow_name, "points": points, "medal": medal, "is_winner": is_winner})
+        is_winner = game.winning_follow and game.winning_follow.name == name
+        follow_results.append({"name": name, "points": follow_points.get(name, 0), "medal": medal, "is_winner": is_winner})
 
-    # Collect round metadata
     rounds_data = []
-
-    # Add all completed rounds that belong to this session
     for r in game.rounds:
         if hasattr(r, "session_id") and r.session_id == session_id:
-            round_data = {
-                "round_num": r.round_num,
-                "session_id": session_id,
-                "pairs": r.pairs,
-                "lead_votes": r.lead_votes,
-                "follow_votes": r.follow_votes,
-                "judges": r.judges,
-                "contestant_judges": r.contestant_judges,
-                "win_messages": r.win_messages,
-                "lead_winner": r.lead_winner,
+            rounds_data.append({
+                "round_num": r.round_num, "session_id": session_id,
+                "pairs": r.pairs, "lead_votes": r.lead_votes, "follow_votes": r.follow_votes,
+                "judges": r.judges, "contestant_judges": r.contestant_judges,
+                "win_messages": r.win_messages, "lead_winner": r.lead_winner,
                 "follow_winner": r.follow_winner,
                 "song_info": r.song_info if hasattr(r, "song_info") else None,
-            }
-            rounds_data.append(round_data)
-
-    # Also include the current round if it exists and is not already in the rounds list
+            })
     if game.current_round and game.current_round not in game.rounds:
         if hasattr(game.current_round, "session_id") and game.current_round.session_id == session_id:
-            current_round_data = {
-                "round_num": game.current_round.round_num,
-                "session_id": session_id,
-                "pairs": game.current_round.pairs,
-                "lead_votes": game.current_round.lead_votes,
-                "follow_votes": game.current_round.follow_votes,
-                "judges": game.current_round.judges,
-                "contestant_judges": game.current_round.contestant_judges,
-                "win_messages": game.current_round.win_messages,
-                "lead_winner": game.current_round.lead_winner,
-                "follow_winner": game.current_round.follow_winner,
-                "song_info": game.current_round.song_info if hasattr(game.current_round, "song_info") else None,
-            }
-            rounds_data.append(current_round_data)
-
-    # Sort rounds by round number
+            r = game.current_round
+            rounds_data.append({
+                "round_num": r.round_num, "session_id": session_id,
+                "pairs": r.pairs, "lead_votes": r.lead_votes, "follow_votes": r.follow_votes,
+                "judges": r.judges, "contestant_judges": r.contestant_judges,
+                "win_messages": r.win_messages, "lead_winner": r.lead_winner,
+                "follow_winner": r.follow_winner,
+                "song_info": r.song_info if hasattr(r, "song_info") else None,
+            })
     rounds_data.sort(key=lambda x: x["round_num"])
 
-    return jsonify(
-        {
-            "session_id": session_id,
-            "leads": lead_results,
-            "follows": follow_results,
-            "rounds": rounds_data,
-            "initial_leads": [c.name for c in game.initial_leads],
-            "initial_follows": [c.name for c in game.initial_follows],
-        }
-    )
+    return {
+        "session_id": session_id,
+        "leads": lead_results,
+        "follows": follow_results,
+        "rounds": rounds_data,
+        "initial_leads": [c.name for c in game.initial_leads],
+        "initial_follows": [c.name for c in game.initial_follows],
+    }
+
+
+@app.route("/api/tiebreak/set_partners", methods=["POST"])
+def tiebreak_set_partners():
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No JSON data provided"}), 400
+    session_id = data.get("session_id")
+    lead_selections = data.get("lead_selections", {})
+    follow_selections = data.get("follow_selections", {})
+    game = repo.get(session_id)
+    if not game:
+        return jsonify({"error": "Invalid session ID"}), 400
+    if not game.tiebreak_active:
+        return jsonify({"error": "No tie-break in progress"}), 400
+    game.set_tiebreak_partner_selections(lead_selections, follow_selections)
+    repo.save(session_id, game)
+    return jsonify({
+        "sub_round": game.tiebreak_sub_round,
+        "sr1_pairings": [list(p) for p in game.tiebreak_sub_round_1_pairings],
+        "sr2_pairings": [list(p) for p in game.tiebreak_sub_round_2_pairings],
+    })
+
+
+@app.route("/api/tiebreak/advance", methods=["POST"])
+def tiebreak_advance():
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No JSON data provided"}), 400
+    session_id = data.get("session_id")
+    game = repo.get(session_id)
+    if not game:
+        return jsonify({"error": "Invalid session ID"}), 400
+    if not game.tiebreak_active:
+        return jsonify({"error": "No tie-break in progress"}), 400
+    new_phase = game.advance_tiebreak_sub_round()
+    repo.save(session_id, game)
+    return jsonify({"sub_round": new_phase})
+
+
+@app.route("/api/tiebreak/vote", methods=["POST"])
+def tiebreak_vote():
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No JSON data provided"}), 400
+    session_id = data.get("session_id")
+    lead_votes_raw = data.get("lead_votes", [])
+    follow_votes_raw = data.get("follow_votes", [])
+    game = repo.get(session_id)
+    if not game:
+        return jsonify({"error": "Invalid session ID"}), 400
+    if not game.tiebreak_active:
+        return jsonify({"error": "No tie-break in progress"}), 400
+
+    lead_result = None
+    follow_result = None
+
+    if game.tiebreak_lead_needed and lead_votes_raw:
+        votes = [(v[0], v[1]) for v in lead_votes_raw]
+        lead_result = game.judge_tiebreak('lead', votes)
+
+    if game.tiebreak_follow_needed and follow_votes_raw:
+        votes = [(v[0], v[1]) for v in follow_votes_raw]
+        follow_result = game.judge_tiebreak('follow', votes)
+
+    repo.save(session_id, game)
+    return jsonify({"lead_result": lead_result, "follow_result": follow_result})
+
+
+@app.route("/api/tiebreak/finalize", methods=["POST"])
+def tiebreak_finalize():
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No JSON data provided"}), 400
+    session_id = data.get("session_id")
+    game = repo.get(session_id)
+    if not game:
+        return jsonify({"error": "Invalid session ID"}), 400
+
+    game.finalize_tiebreak_results()
+    repo.save(session_id, game)
+
+    result = _format_end_game_results(game, session_id)
+    result["tiebreak_winners"] = {
+        "lead": game.winning_lead.name if game.winning_lead else None,
+        "follow": game.winning_follow.name if game.winning_follow else None,
+    }
+    return jsonify(result)
 
 
 @app.route("/api/export_battle_data", methods=["GET", "POST"])

--- a/web/app.py
+++ b/web/app.py
@@ -358,6 +358,18 @@ def serialize_state(game: Game) -> dict:
             "follows": ([game.pair_1[1].name, game.pair_2[1].name] if game.pair_1 and game.pair_2 else [])
             + [c.name for c in game.follows],
         },
+        "tiebreak": {
+            "active": game.tiebreak_active,
+            "sub_round": game.tiebreak_sub_round,
+            "lead_needed": game.tiebreak_lead_needed,
+            "follow_needed": game.tiebreak_follow_needed,
+            "tied_leads": [c.name for c in game.tiebreak_leads_tied],
+            "tied_follows": [c.name for c in game.tiebreak_follows_tied],
+            "sr1_pairings": [list(p) for p in game.tiebreak_sub_round_1_pairings],
+            "sr2_pairings": [list(p) for p in game.tiebreak_sub_round_2_pairings],
+            "lead_winner": game.tiebreak_lead_winner.name if game.tiebreak_lead_winner else None,
+            "follow_winner": game.tiebreak_follow_winner.name if game.tiebreak_follow_winner else None,
+        },
     }
     return state
 

--- a/web/app.py
+++ b/web/app.py
@@ -757,7 +757,7 @@ def end_game():
     if tiebreak_info['lead_needed'] or tiebreak_info['follow_needed']:
         game.start_tiebreak()
         repo.save(session_id, game)
-        judges = getattr(game.current_round, 'judges', {}) if game.current_round else {}
+        r = game.current_round
         return jsonify({
             'tiebreak_required': True,
             'lead_needed': tiebreak_info['lead_needed'],
@@ -768,8 +768,8 @@ def end_game():
             'follow_max_points': tiebreak_info['follow_max_points'],
             'all_leads': [c.name for c in game.initial_leads],
             'all_follows': [c.name for c in game.initial_follows],
-            'guest_judges': judges.get('guest', []),
-            'contestant_judges': judges.get('contestant', []),
+            'guest_judges': (r.judges if r else []) or game.guest_judges,
+            'contestant_judges': (r.contestant_judges if r else []),
         })
 
     # No tie-break needed — mark the game as finished and return results
@@ -898,7 +898,18 @@ def tiebreak_vote():
         follow_result = game.judge_tiebreak('follow', votes)
 
     repo.save(session_id, game)
-    return jsonify({"lead_result": lead_result, "follow_result": follow_result})
+
+    needs_another_round = (
+        (lead_result is not None and not lead_result.get('resolved')) or
+        (follow_result is not None and not follow_result.get('resolved'))
+    )
+    return jsonify({
+        "lead_result": lead_result,
+        "follow_result": follow_result,
+        "needs_another_round": needs_another_round,
+        "tied_leads": [c.name for c in game.tiebreak_leads_tied],
+        "tied_follows": [c.name for c in game.tiebreak_follows_tied],
+    })
 
 
 @app.route("/api/tiebreak/finalize", methods=["POST"])

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -1410,6 +1410,58 @@ input[type="checkbox"] {
     margin-bottom: 4px;
 }
 
+.accordion-header.tiebreak {
+    border-left: 3px solid var(--accent);
+}
+
+.tiebreak-history-badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    background: var(--accent-light);
+    border: 1px solid var(--accent);
+    border-radius: 999px;
+    padding: 1px 7px;
+    margin-left: 8px;
+    vertical-align: middle;
+}
+
+.tiebreak-history-group {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+}
+
+.tiebreak-history-role-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    min-width: 48px;
+}
+
+.tiebreak-history-names {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.tiebreak-history-vs {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.tiebreak-history-winner {
+    font-weight: 700;
+}
+
 /* ============================================================
    21. Display Mode Specific
    ============================================================ */

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -1508,6 +1508,30 @@ input[type="checkbox"] {
         height: 100%;
         overflow: hidden;
     }
+
+    [data-mode="display"] #results-screen {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    [data-mode="display"] #results-screen .battle-graphic-section {
+        flex: 1;
+        min-height: 0;
+        margin-bottom: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    [data-mode="display"] #results-screen .battle-graphic {
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+        align-content: start;
+    }
 }
 
 /* Round transition overlay */
@@ -2410,35 +2434,11 @@ a {
    32. Results Screen — Display Mode
    ============================================================ */
 
-[data-mode="display"] #results-screen {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
-
 [data-mode="display"] #results-screen > h2,
 [data-mode="display"] #results-screen .leaderboard,
 [data-mode="display"] #results-screen .round-history,
 [data-mode="display"] #results-screen .results-actions {
     display: none;
-}
-
-[data-mode="display"] #results-screen .battle-graphic-section {
-    flex: 1;
-    min-height: 0;
-    margin-bottom: 0;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
-
-[data-mode="display"] #results-screen .battle-graphic {
-    flex: 1;
-    min-height: 0;
-    overflow: auto;
-    align-content: start;
 }
 
 [data-mode="display"] #results-screen .graphic-column h4 {

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -2407,7 +2407,56 @@ a {
 }
 
 /* ============================================================
-   32. Tie-Break Display Mode (projector / audience view)
+   32. Results Screen — Display Mode
+   ============================================================ */
+
+[data-mode="display"] #results-screen {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+[data-mode="display"] #results-screen > h2,
+[data-mode="display"] #results-screen .leaderboard,
+[data-mode="display"] #results-screen .round-history,
+[data-mode="display"] #results-screen .results-actions {
+    display: none;
+}
+
+[data-mode="display"] #results-screen .battle-graphic-section {
+    flex: 1;
+    min-height: 0;
+    margin-bottom: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+[data-mode="display"] #results-screen .battle-graphic {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    align-content: start;
+}
+
+[data-mode="display"] #results-screen .graphic-column h4 {
+    font-size: clamp(14px, 2vh, 20px);
+    margin-bottom: clamp(8px, 1.2vh, 16px);
+}
+
+[data-mode="display"] #results-screen .graphic-row {
+    padding: clamp(6px, 1vh, 12px) clamp(8px, 1.2vh, 16px);
+}
+
+[data-mode="display"] #results-screen .graphic-name,
+[data-mode="display"] #results-screen .badge {
+    font-size: clamp(14px, 2vh, 22px);
+}
+
+/* ============================================================
+   33. Tie-Break Display Mode (projector / audience view)
    ============================================================ */
 
 [data-mode="display"] #tiebreak-display-section {

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -2301,3 +2301,55 @@ a {
     font-weight: 700;
     color: var(--text-primary);
 }
+
+.tiebreak-still-tied-section {
+    margin-bottom: var(--space-md);
+}
+
+.tiebreak-still-tied-section h4 {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin-bottom: var(--space-sm);
+}
+
+.tiebreak-vote-tally {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.tiebreak-tally-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+}
+
+.tiebreak-tally-row.tiebreak-tally-tied {
+    border-color: var(--accent);
+    background: var(--accent-light);
+}
+
+.tiebreak-tally-score {
+    margin-left: auto;
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.tiebreak-tally-badge {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--accent);
+    padding: 2px 6px;
+    border: 1px solid var(--accent);
+    border-radius: 999px;
+}

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -1484,7 +1484,7 @@ input[type="checkbox"] {
         padding-bottom: max(12px, 1.5vh);
     }
 
-    [data-mode="display"] #battle-screen {
+    [data-mode="display"] #battle-screen.active {
         flex: 1;
         min-height: 0;
         display: flex;
@@ -1509,7 +1509,7 @@ input[type="checkbox"] {
         overflow: hidden;
     }
 
-    [data-mode="display"] #results-screen {
+    [data-mode="display"] #results-screen.active {
         flex: 1;
         min-height: 0;
         display: flex;

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -2353,3 +2353,110 @@ a {
     border: 1px solid var(--accent);
     border-radius: 999px;
 }
+
+/* ============================================================
+   32. Tie-Break Display Mode (projector / audience view)
+   ============================================================ */
+
+[data-mode="display"] #tiebreak-display-section {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(12px, 2vh, 28px);
+    padding: clamp(8px, 1.5vh, 20px);
+}
+
+.tiebreak-display-phase {
+    font-size: clamp(18px, 3vh, 32px);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent);
+    text-align: center;
+}
+
+.tiebreak-display-contestants {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(10px, 1.8vh, 20px);
+}
+
+.tiebreak-display-role-group {
+    display: flex;
+    align-items: center;
+    gap: clamp(8px, 1.5vh, 20px);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.tiebreak-display-role-label {
+    font-size: clamp(11px, 1.5vh, 16px);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+}
+
+.tiebreak-display-name {
+    font-size: clamp(20px, 3.5vh, 40px);
+    font-weight: 700;
+}
+
+.tiebreak-display-vs {
+    font-size: clamp(14px, 2vh, 22px);
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.tiebreak-display-pairings {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(8px, 1.5vh, 16px);
+    width: 100%;
+    max-width: 640px;
+}
+
+.tiebreak-display-pairing-card {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(8px, 1.5vh, 20px);
+    padding: clamp(10px, 1.8vh, 20px) clamp(16px, 2.5vh, 32px);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    font-size: clamp(18px, 3vh, 34px);
+    font-weight: 700;
+}
+
+.tiebreak-display-plus {
+    color: var(--text-muted);
+    font-size: clamp(16px, 2.5vh, 28px);
+}
+
+.tiebreak-display-winners {
+    display: flex;
+    gap: clamp(12px, 2vh, 24px);
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.tiebreak-display-winner-banner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: clamp(12px, 2vh, 24px) clamp(20px, 3vh, 40px);
+    background: var(--accent-light);
+    border: 2px solid var(--accent);
+    border-radius: var(--radius-lg);
+}
+
+.tiebreak-display-winner-name {
+    font-size: clamp(22px, 4vh, 48px);
+    font-weight: 800;
+}

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -2166,3 +2166,138 @@ a {
 @media (min-width: 1400px) {
     [data-mode="display"] .round-number-large { font-size: 16rem; }
 }
+
+/* ============================================================
+   31. Tie-Break Mode
+   ============================================================ */
+.modal--tiebreak {
+    max-width: 600px;
+}
+
+.tiebreak-subtitle {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin-bottom: var(--space-lg);
+}
+
+.tiebreak-partner-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: var(--space-lg);
+}
+
+.tiebreak-partner-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.tiebreak-lead-name,
+.tiebreak-follow-name {
+    min-width: 110px;
+    font-weight: 600;
+    font-size: 15px;
+}
+
+.tiebreak-arrow {
+    color: var(--text-muted);
+    font-size: 18px;
+}
+
+.tiebreak-partner-select {
+    flex: 1;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.tiebreak-partner-select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.tiebreak-pairings {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: var(--space-lg);
+}
+
+.tiebreak-pairing-card {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    font-size: 15px;
+    font-weight: 500;
+}
+
+.tiebreak-vs {
+    color: var(--text-muted);
+    font-size: 13px;
+}
+
+.tiebreak-note {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-bottom: var(--space-md);
+}
+
+.tiebreak-voting-section {
+    margin-bottom: var(--space-lg);
+}
+
+.tiebreak-voting-section h4 {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: var(--space-md);
+}
+
+.tiebreak-section-divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: var(--space-lg) 0;
+}
+
+.tiebreak-results {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: var(--space-sm) 0;
+}
+
+.tiebreak-winner-banner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 20px;
+    background: var(--accent-light);
+    border: 2px solid var(--accent);
+    border-radius: var(--radius-md);
+}
+
+.tiebreak-role-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+}
+
+.tiebreak-winner-name {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--text-primary);
+}

--- a/web/index.html
+++ b/web/index.html
@@ -214,6 +214,13 @@
                 <p class="vote-progress" id="vote-progress"></p>
             </div>
 
+            <div id="tiebreak-display-section" style="display:none;">
+                <div id="tiebreak-display-phase-label" class="tiebreak-display-phase"></div>
+                <div id="tiebreak-display-contestants" class="tiebreak-display-contestants"></div>
+                <div id="tiebreak-display-pairings" class="tiebreak-display-pairings"></div>
+                <div id="tiebreak-display-winners" class="tiebreak-display-winners"></div>
+            </div>
+
             <div class="round-header">
                 <div class="round-info-container">
                     <div class="round-content">

--- a/web/index.html
+++ b/web/index.html
@@ -377,6 +377,17 @@
                     </div>
                 </div>
 
+                <!-- Tie-break modal -->
+                <div id="tiebreak-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="tiebreak-modal-title">
+                    <div class="modal modal--tiebreak">
+                        <div class="modal-header">
+                            <h3 id="tiebreak-modal-title">Tie-Break</h3>
+                        </div>
+                        <div class="modal-body" id="tiebreak-modal-body"></div>
+                        <div class="modal-footer" id="tiebreak-modal-footer"></div>
+                    </div>
+                </div>
+
                 <!-- Vote confirmation modal -->
                 <div id="vote-confirm-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="vote-confirm-title">
                     <div class="modal">

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2835,12 +2835,15 @@ function displayRoundHistory(rounds) {
     // Create an accordion item for each round
     rounds.forEach(round => {
         const accordionItem = document.createElement('div');
-        accordionItem.className = 'accordion-item';
-        
+        accordionItem.className = 'accordion-item' + (round.tiebreak ? ' tiebreak' : '');
+
         // Create the header
         const header = document.createElement('div');
-        header.className = 'accordion-header';
-        header.innerHTML = `<span>Round ${round.round_num}</span><span>+</span>`;
+        header.className = 'accordion-header' + (round.tiebreak ? ' tiebreak' : '');
+        const headerLabel = round.tiebreak
+            ? `Round ${round.round_num} <span class="tiebreak-history-badge">Tie-Break</span>`
+            : `Round ${round.round_num}`;
+        header.innerHTML = `<span>${headerLabel}</span><span>+</span>`;
         
         // Add click handler for accordion functionality
         header.addEventListener('click', () => {
@@ -2912,42 +2915,66 @@ function displayRoundHistory(rounds) {
         // Participants section
         const participants = document.createElement('div');
         participants.className = 'round-participants';
-        
-        let participantsHTML = '<h4>Participants</h4>';
-        
-        if (round.pairs && Object.keys(round.pairs).length > 0) {
-            // First pair
-            participantsHTML += `
-                <div class="match-pair">
-                    <div>Couple 1:</div>
-                    <div><span class="lead">${round.pairs.pair_1.lead}</span> (Lead) & 
-                    <span class="follow">${round.pairs.pair_1.follow}</span> (Follow)</div>
-                </div>
-                <div class="match-pair">
-                    <div>Couple 2:</div>
-                    <div><span class="lead">${round.pairs.pair_2.lead}</span> (Lead) & 
-                    <span class="follow">${round.pairs.pair_2.follow}</span> (Follow)</div>
-                </div>
-            `;
-            
-            // Add winners if available
-            if (round.lead_winner) {
-                participantsHTML += `<div class="winner">Lead Winner: ${round.lead_winner}</div>`;
-            }
-            
-            if (round.follow_winner) {
-                participantsHTML += `<div class="winner">Follow Winner: ${round.follow_winner}</div>`;
-            }
-        } else {
-            participantsHTML += '<p>No participant data available for this round.</p>';
-        }
-        
-        participants.innerHTML = participantsHTML;
-        topRow.appendChild(participants);
-        // Ensure the top row (participants + song) is above judge votes
-        details.appendChild(topRow);
 
-        // Add judge votes section
+        if (round.tiebreak) {
+            let html = '<h4>Tie-Break</h4>';
+            if (round.tiebreak_leads?.length) {
+                html += `<div class="tiebreak-history-group">
+                    <span class="tiebreak-history-role-label">Leads</span>
+                    <span class="tiebreak-history-names">
+                        ${round.tiebreak_leads.map(n =>
+                            `<span class="contestant lead${round.lead_winner === n ? ' tiebreak-history-winner' : ''}">${n}${round.lead_winner === n ? ' 🏆' : ''}</span>`
+                        ).join('<span class="tiebreak-history-vs">vs</span>')}
+                    </span>
+                </div>`;
+            }
+            if (round.tiebreak_follows?.length) {
+                html += `<div class="tiebreak-history-group">
+                    <span class="tiebreak-history-role-label">Follows</span>
+                    <span class="tiebreak-history-names">
+                        ${round.tiebreak_follows.map(n =>
+                            `<span class="contestant follow${round.follow_winner === n ? ' tiebreak-history-winner' : ''}">${n}${round.follow_winner === n ? ' 🏆' : ''}</span>`
+                        ).join('<span class="tiebreak-history-vs">vs</span>')}
+                    </span>
+                </div>`;
+            }
+            participants.innerHTML = html;
+            topRow.appendChild(participants);
+            details.appendChild(topRow);
+        } else {
+            let participantsHTML = '<h4>Participants</h4>';
+            if (round.pairs && Object.keys(round.pairs).length > 0) {
+                participantsHTML += `
+                    <div class="match-pair">
+                        <div>Couple 1:</div>
+                        <div><span class="lead">${round.pairs.pair_1.lead}</span> (Lead) &
+                        <span class="follow">${round.pairs.pair_1.follow}</span> (Follow)</div>
+                    </div>
+                    <div class="match-pair">
+                        <div>Couple 2:</div>
+                        <div><span class="lead">${round.pairs.pair_2.lead}</span> (Lead) &
+                        <span class="follow">${round.pairs.pair_2.follow}</span> (Follow)</div>
+                    </div>
+                `;
+                if (round.lead_winner) participantsHTML += `<div class="winner">Lead Winner: ${round.lead_winner}</div>`;
+                if (round.follow_winner) participantsHTML += `<div class="winner">Follow Winner: ${round.follow_winner}</div>`;
+            } else {
+                participantsHTML += '<p>No participant data available for this round.</p>';
+            }
+            participants.innerHTML = participantsHTML;
+            topRow.appendChild(participants);
+            details.appendChild(topRow);
+        }
+
+        // Add judge votes section (normal rounds only)
+        if (round.tiebreak) {
+            content.appendChild(details);
+            accordionItem.appendChild(header);
+            accordionItem.appendChild(content);
+            roundsContainer.appendChild(accordionItem);
+            return;
+        }
+
         const judgeVotes = document.createElement('div');
         judgeVotes.className = 'judge-votes';
         let judgeVotesHTML = '<h4>Judge Votes</h4>';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2685,13 +2685,24 @@ async function displayResults(data) {
         const followMap = new Map();
         const totalRounds = data.rounds.length;
         data.rounds.forEach(r => {
+            const roundNum = r.round_num;
+            if (r.tiebreak) {
+                (r.tiebreak_leads || []).forEach(name => {
+                    if (!leadMap.has(name)) leadMap.set(name, []);
+                    leadMap.get(name).push({ round: roundNum, win: r.lead_winner === name });
+                });
+                (r.tiebreak_follows || []).forEach(name => {
+                    if (!followMap.has(name)) followMap.set(name, []);
+                    followMap.get(name).push({ round: roundNum, win: r.follow_winner === name });
+                });
+                return;
+            }
             const pair1Lead = r.pairs?.pair_1?.lead;
             const pair1Follow = r.pairs?.pair_1?.follow;
             const pair2Lead = r.pairs?.pair_2?.lead;
             const pair2Follow = r.pairs?.pair_2?.follow;
             const leadWinner = r.lead_winner;
             const followWinner = r.follow_winner;
-            const roundNum = r.round_num;
             if (pair1Lead) {
                 if (!leadMap.has(pair1Lead)) leadMap.set(pair1Lead, []);
                 leadMap.get(pair1Lead).push({ round: roundNum, win: leadWinner === pair1Lead });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -862,8 +862,78 @@ async function fetchCanonicalState() {
     return await resp.json();
 }
 
+function renderDisplayModeTiebreak(tb) {
+    document.getElementById('tiebreak-display-section').style.display = '';
+    document.querySelector('.round-header').style.display = 'none';
+
+    const phaseEl = document.getElementById('tiebreak-display-phase-label');
+    const contestantsEl = document.getElementById('tiebreak-display-contestants');
+    const pairingsEl = document.getElementById('tiebreak-display-pairings');
+    const winnersEl = document.getElementById('tiebreak-display-winners');
+
+    const phaseLabels = {
+        0: 'Tie-Break — Selecting Partners',
+        1: 'Tie-Break — Sub-Round 1',
+        2: 'Tie-Break — Sub-Round 2',
+        3: 'Tie-Break — Final Vote',
+    };
+    phaseEl.textContent = phaseLabels[tb.sub_round] ?? 'Tie-Break';
+
+    if (tb.sub_round === 0 || tb.sub_round === 3) {
+        let html = '';
+        if (tb.lead_needed && tb.tied_leads.length && !tb.lead_winner) {
+            html += `<div class="tiebreak-display-role-group">
+                <span class="tiebreak-display-role-label">Leads</span>
+                ${tb.tied_leads.map(n => `<span class="contestant lead tiebreak-display-name">${n}</span>`).join('<span class="tiebreak-display-vs">vs</span>')}
+            </div>`;
+        }
+        if (tb.follow_needed && tb.tied_follows.length && !tb.follow_winner) {
+            html += `<div class="tiebreak-display-role-group">
+                <span class="tiebreak-display-role-label">Follows</span>
+                ${tb.tied_follows.map(n => `<span class="contestant follow tiebreak-display-name">${n}</span>`).join('<span class="tiebreak-display-vs">vs</span>')}
+            </div>`;
+        }
+        contestantsEl.innerHTML = html;
+        pairingsEl.innerHTML = '';
+    }
+
+    if (tb.sub_round === 1 || tb.sub_round === 2) {
+        const pairings = tb.sub_round === 1 ? tb.sr1_pairings : tb.sr2_pairings;
+        contestantsEl.innerHTML = '';
+        pairingsEl.innerHTML = pairings.map(([lead, follow]) =>
+            `<div class="tiebreak-display-pairing-card">
+                <span class="contestant lead">${lead}</span>
+                <span class="tiebreak-display-plus">+</span>
+                <span class="contestant follow">${follow}</span>
+            </div>`
+        ).join('');
+    }
+
+    let winnerHtml = '';
+    if (tb.lead_winner) winnerHtml += `<div class="tiebreak-display-winner-banner">
+        <span class="tiebreak-display-role-label">Lead Winner</span>
+        <span class="tiebreak-display-winner-name contestant lead">${tb.lead_winner}</span>
+    </div>`;
+    if (tb.follow_winner) winnerHtml += `<div class="tiebreak-display-winner-banner">
+        <span class="tiebreak-display-role-label">Follow Winner</span>
+        <span class="tiebreak-display-winner-name contestant follow">${tb.follow_winner}</span>
+    </div>`;
+    winnersEl.innerHTML = winnerHtml;
+}
+
 function renderFromState(state) {
     if (!state || !state.round || !state.round.pairs) return;
+
+    // Display mode: hand off to tiebreak renderer when a tiebreak is active
+    if (displayMode && state.tiebreak?.active) {
+        renderDisplayModeTiebreak(state.tiebreak);
+        return;
+    }
+    // Restore normal display layout if tiebreak just ended
+    if (displayMode) {
+        document.getElementById('tiebreak-display-section').style.display = 'none';
+        document.querySelector('.round-header').style.display = '';
+    }
 
     // Store initial order for results display (important for display mode)
     if (Array.isArray(state.initial_order?.leads)) initialLeads = state.initial_order.leads;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -48,6 +48,8 @@ let tiebreakLeadVotes = {};
 let tiebreakFollowVotes = {};
 let tiebreakGuestJudges = [];
 let tiebreakContestantJudges = [];
+let tiebreakResolvedLeadWinner = null;
+let tiebreakResolvedFollowWinner = null;
 
 // Voting constants (frontend-only)
 const PROXY_CONTESTANT_JUDGES_NAME = 'Contestant Judges';
@@ -3209,6 +3211,8 @@ function startTiebreakFlow(data) {
     tiebreakFollowVotes = {};
     tiebreakGuestJudges = data.guest_judges || [];
     tiebreakContestantJudges = data.contestant_judges || [];
+    tiebreakResolvedLeadWinner = null;
+    tiebreakResolvedFollowWinner = null;
     renderTiebreakPhase0();
     document.getElementById('tiebreak-modal').classList.remove('hidden');
 }
@@ -3376,11 +3380,12 @@ function renderTiebreakPhase3() {
     if (tiebreakLeadNeeded && tiedLeads.length >= 2) {
         const section = document.createElement('div');
         section.className = 'tiebreak-voting-section';
-        section.innerHTML = `<h4>Lead Tie-Break: <span class="contestant lead">${tiedLeads[0]}</span> vs <span class="contestant lead">${tiedLeads[1]}</span></h4>`;
+        const leadVsList = tiedLeads.map(n => `<span class="contestant lead">${n}</span>`).join(' vs ');
+        section.innerHTML = `<h4>Lead Tie-Break: ${leadVsList}</h4>`;
         const container = document.createElement('div');
         container.className = 'judges-container';
         allJudges.forEach(judge => {
-            container.appendChild(createTiebreakJudgeCard(judge, tiebreakGuestJudges.includes(judge), 'tb-lead', tiedLeads[0], tiedLeads[1]));
+            container.appendChild(createTiebreakJudgeCard(judge, tiebreakGuestJudges.includes(judge), 'tb-lead', tiedLeads));
         });
         section.appendChild(container);
         body.appendChild(section);
@@ -3394,11 +3399,12 @@ function renderTiebreakPhase3() {
         }
         const section = document.createElement('div');
         section.className = 'tiebreak-voting-section';
-        section.innerHTML = `<h4>Follow Tie-Break: <span class="contestant follow">${tiedFollows[0]}</span> vs <span class="contestant follow">${tiedFollows[1]}</span></h4>`;
+        const followVsList = tiedFollows.map(n => `<span class="contestant follow">${n}</span>`).join(' vs ');
+        section.innerHTML = `<h4>Follow Tie-Break: ${followVsList}</h4>`;
         const container = document.createElement('div');
         container.className = 'judges-container';
         allJudges.forEach(judge => {
-            container.appendChild(createTiebreakJudgeCard(judge, tiebreakGuestJudges.includes(judge), 'tb-follow', tiedFollows[0], tiedFollows[1]));
+            container.appendChild(createTiebreakJudgeCard(judge, tiebreakGuestJudges.includes(judge), 'tb-follow', tiedFollows));
         });
         section.appendChild(container);
         body.appendChild(section);
@@ -3408,7 +3414,7 @@ function renderTiebreakPhase3() {
     document.getElementById('tiebreak-submit-votes').addEventListener('click', submitTiebreakVotes);
 }
 
-function createTiebreakJudgeCard(judgeName, isGuest, voteType, name1, name2) {
+function createTiebreakJudgeCard(judgeName, isGuest, voteType, names) {
     const row = document.createElement('div');
     row.className = 'judge-row';
 
@@ -3423,28 +3429,24 @@ function createTiebreakJudgeCard(judgeName, isGuest, voteType, name1, name2) {
     const chips = document.createElement('div');
     chips.className = 'vote-chips';
 
-    function onChip(chip, val) {
+    function onChip(chip, chosenName) {
         chips.querySelectorAll('.vote-chip').forEach(c => c.classList.remove('selected'));
         chip.classList.add('selected');
         row.classList.add('voted');
         avatar.classList.add('voted');
-        if (voteType === 'tb-lead') tiebreakLeadVotes[judgeName] = val;
-        else tiebreakFollowVotes[judgeName] = val;
+        if (voteType === 'tb-lead') tiebreakLeadVotes[judgeName] = chosenName;
+        else tiebreakFollowVotes[judgeName] = chosenName;
         updateTiebreakSubmitState();
     }
 
-    const chip1 = document.createElement('button');
-    chip1.className = 'vote-chip';
-    chip1.textContent = name1;
-    chip1.addEventListener('click', () => onChip(chip1, 1));
+    names.forEach(name => {
+        const chip = document.createElement('button');
+        chip.className = 'vote-chip';
+        chip.textContent = name;
+        chip.addEventListener('click', () => onChip(chip, name));
+        chips.appendChild(chip);
+    });
 
-    const chip2 = document.createElement('button');
-    chip2.className = 'vote-chip';
-    chip2.textContent = name2;
-    chip2.addEventListener('click', () => onChip(chip2, 2));
-
-    chips.appendChild(chip1);
-    chips.appendChild(chip2);
     row.appendChild(avatar);
     row.appendChild(nameEl);
     row.appendChild(chips);
@@ -3472,10 +3474,69 @@ async function submitTiebreakVotes() {
             body: JSON.stringify({ session_id: sessionId, lead_votes: leadVotesArray, follow_votes: followVotesArray }),
         });
         const data = await resp.json();
-        renderTiebreakResults(data);
+
+        if (data.lead_result?.resolved) {
+            tiebreakLeadNeeded = false;
+            tiebreakResolvedLeadWinner = data.lead_result.winner;
+        }
+        if (data.follow_result?.resolved) {
+            tiebreakFollowNeeded = false;
+            tiebreakResolvedFollowWinner = data.follow_result.winner;
+        }
+
+        if (data.needs_another_round) {
+            tiedLeads = data.tied_leads || tiedLeads;
+            tiedFollows = data.tied_follows || tiedFollows;
+            renderTiebreakStillTied(data);
+        } else {
+            renderTiebreakResults(data);
+        }
     } catch (e) {
         showToast('Failed to submit tie-break votes', 'error');
     }
+}
+
+function renderTiebreakStillTied(data) {
+    document.getElementById('tiebreak-modal-title').textContent = 'Tie-Break: Votes Tied';
+    const body = document.getElementById('tiebreak-modal-body');
+    const footer = document.getElementById('tiebreak-modal-footer');
+
+    let html = '<p class="tiebreak-subtitle">The vote ended in a tie. Another round is needed.</p>';
+
+    const buildTallyHtml = (result, role) => {
+        const colorClass = role === 'lead' ? 'lead' : 'follow';
+        let h = '<div class="tiebreak-vote-tally">';
+        Object.entries(result.vote_tally).sort((a, b) => b[1] - a[1]).forEach(([name, score]) => {
+            const tied = result.still_tied && result.still_tied.includes(name);
+            h += `<div class="tiebreak-tally-row${tied ? ' tiebreak-tally-tied' : ''}">
+                <span class="contestant ${colorClass}">${name}</span>
+                <span class="tiebreak-tally-score">${score} pt${score !== 1 ? 's' : ''}</span>
+                ${tied ? '<span class="tiebreak-tally-badge">tied</span>' : ''}
+            </div>`;
+        });
+        h += '</div>';
+        return h;
+    };
+
+    if (data.lead_result && !data.lead_result.resolved) {
+        html += `<div class="tiebreak-still-tied-section"><h4>Lead Vote — Still Tied</h4>${buildTallyHtml(data.lead_result, 'lead')}</div>`;
+    } else if (tiebreakResolvedLeadWinner) {
+        html += `<div class="tiebreak-winner-banner"><span class="tiebreak-role-label">Lead Winner</span><span class="tiebreak-winner-name contestant lead">${tiebreakResolvedLeadWinner}</span></div>`;
+    }
+
+    if (data.lead_result && !data.lead_result.resolved && data.follow_result) {
+        html += '<hr class="tiebreak-section-divider">';
+    }
+
+    if (data.follow_result && !data.follow_result.resolved) {
+        html += `<div class="tiebreak-still-tied-section"><h4>Follow Vote — Still Tied</h4>${buildTallyHtml(data.follow_result, 'follow')}</div>`;
+    } else if (tiebreakResolvedFollowWinner) {
+        html += `<div class="tiebreak-winner-banner"><span class="tiebreak-role-label">Follow Winner</span><span class="tiebreak-winner-name contestant follow">${tiebreakResolvedFollowWinner}</span></div>`;
+    }
+
+    body.innerHTML = html;
+    footer.innerHTML = '<button id="tiebreak-next-round-btn" class="btn primary">Continue Tie-Break →</button>';
+    document.getElementById('tiebreak-next-round-btn').addEventListener('click', renderTiebreakPhase0);
 }
 
 function renderTiebreakResults(data) {
@@ -3484,16 +3545,16 @@ function renderTiebreakResults(data) {
     const footer = document.getElementById('tiebreak-modal-footer');
 
     let html = '<div class="tiebreak-results">';
-    if (data.lead_result) {
+    if (tiebreakResolvedLeadWinner) {
         html += `<div class="tiebreak-winner-banner">
             <span class="tiebreak-role-label">Lead Winner</span>
-            <span class="tiebreak-winner-name">${data.lead_result.winner} 👑</span>
+            <span class="tiebreak-winner-name contestant lead">${tiebreakResolvedLeadWinner}</span>
         </div>`;
     }
-    if (data.follow_result) {
+    if (tiebreakResolvedFollowWinner) {
         html += `<div class="tiebreak-winner-banner">
             <span class="tiebreak-role-label">Follow Winner</span>
-            <span class="tiebreak-winner-name">${data.follow_result.winner} 👑</span>
+            <span class="tiebreak-winner-name contestant follow">${tiebreakResolvedFollowWinner}</span>
         </div>`;
     }
     html += '</div>';

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2855,7 +2855,7 @@ function displayRoundHistory(rounds) {
             content.classList.toggle('open');
 
             // Update the plus/minus symbol
-            const symbol = header.querySelector('span:last-child');
+            const symbol = header.lastElementChild;
             symbol.textContent = isOpen ? '+' : '-';
         });
         

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -33,6 +33,22 @@ let demoStep = 0;
 let demoOverlay = null; // Container for backdrop + hint
 let demoWaitingForAction = false; // True when waiting for user interaction before enabling Next
 
+// Tie-break state
+let tiebreakActive = false;
+let tiebreakLeadNeeded = false;
+let tiebreakFollowNeeded = false;
+let tiedLeads = [];
+let tiedFollows = [];
+let tiebreakAllLeads = [];
+let tiebreakAllFollows = [];
+let tiebreakSubRound = 0;
+let tiebreakSR1Pairings = [];
+let tiebreakSR2Pairings = [];
+let tiebreakLeadVotes = {};
+let tiebreakFollowVotes = {};
+let tiebreakGuestJudges = [];
+let tiebreakContestantJudges = [];
+
 // Voting constants (frontend-only)
 const PROXY_CONTESTANT_JUDGES_NAME = 'Contestant Judges';
 const VOTE_MIXED = 5; // Special option used only for the proxy judge UI (never sent to backend)
@@ -3152,14 +3168,19 @@ function endGame() {
     .then(response => response.json())
     .then(data => {
         console.log('Received end game data:', data);
-        
+
+        if (data.tiebreak_required) {
+            startTiebreakFlow(data);
+            return;
+        }
+
         // Ensure we have the initial order data
         if (!data.initial_leads || !data.initial_follows) {
             console.log('Using stored initial order data');
             data.initial_leads = initialLeads;
             data.initial_follows = initialFollows;
         }
-        
+
         // Display final results
         displayResults(data);
     })
@@ -3168,6 +3189,339 @@ function endGame() {
         showToast('Failed to end the competition', 'error');
     });
 } 
+
+// ============================================================
+// Tie-Break Flow
+// ============================================================
+
+function startTiebreakFlow(data) {
+    tiebreakActive = true;
+    tiebreakLeadNeeded = data.lead_needed;
+    tiebreakFollowNeeded = data.follow_needed;
+    tiedLeads = data.tied_leads || [];
+    tiedFollows = data.tied_follows || [];
+    tiebreakAllLeads = data.all_leads || [];
+    tiebreakAllFollows = data.all_follows || [];
+    tiebreakSubRound = 0;
+    tiebreakSR1Pairings = [];
+    tiebreakSR2Pairings = [];
+    tiebreakLeadVotes = {};
+    tiebreakFollowVotes = {};
+    tiebreakGuestJudges = data.guest_judges || [];
+    tiebreakContestantJudges = data.contestant_judges || [];
+    renderTiebreakPhase0();
+    document.getElementById('tiebreak-modal').classList.remove('hidden');
+}
+
+function renderTiebreakPhase0() {
+    document.getElementById('tiebreak-modal-title').textContent = 'Tie-Break: Partner Selection';
+    const body = document.getElementById('tiebreak-modal-body');
+    const footer = document.getElementById('tiebreak-modal-footer');
+
+    let html = '<p class="tiebreak-subtitle">Tied dancers must each choose a partner for the tie-break round.</p>';
+
+    if (tiebreakLeadNeeded) {
+        html += '<div class="tiebreak-partner-grid" id="tiebreak-lead-partner-grid">';
+        tiedLeads.forEach(lead => {
+            const safeId = lead.replace(/\s+/g, '-').toLowerCase();
+            html += `<div class="tiebreak-partner-row">
+                <span class="tiebreak-lead-name contestant lead">${lead}</span>
+                <span class="tiebreak-arrow">→</span>
+                <select class="tiebreak-partner-select" data-role="lead" data-name="${lead}" id="tiebreak-lead-select-${safeId}">
+                    <option value="">Select a follow…</option>
+                    ${tiebreakAllFollows.map(f => `<option value="${f}">${f}</option>`).join('')}
+                </select>
+            </div>`;
+        });
+        html += '</div>';
+    }
+
+    if (tiebreakFollowNeeded) {
+        if (tiebreakLeadNeeded) html += '<hr class="tiebreak-section-divider">';
+        html += '<div class="tiebreak-partner-grid" id="tiebreak-follow-partner-grid">';
+        tiedFollows.forEach(follow => {
+            const safeId = follow.replace(/\s+/g, '-').toLowerCase();
+            html += `<div class="tiebreak-partner-row">
+                <span class="tiebreak-follow-name contestant follow">${follow}</span>
+                <span class="tiebreak-arrow">→</span>
+                <select class="tiebreak-partner-select" data-role="follow" data-name="${follow}" id="tiebreak-follow-select-${safeId}">
+                    <option value="">Select a lead…</option>
+                    ${tiebreakAllLeads.map(l => `<option value="${l}">${l}</option>`).join('')}
+                </select>
+            </div>`;
+        });
+        html += '</div>';
+    }
+
+    body.innerHTML = html;
+    body.querySelectorAll('.tiebreak-partner-select').forEach(sel => {
+        sel.addEventListener('change', () => {
+            syncTiebreakSelects();
+            updateTiebreakPartnerConfirmState();
+        });
+    });
+
+    footer.innerHTML = '<button id="tiebreak-confirm-partners" class="btn primary" disabled>Confirm Partners</button>';
+    document.getElementById('tiebreak-confirm-partners').addEventListener('click', submitTiebreakPartnerSelections);
+}
+
+function syncTiebreakSelects() {
+    // Disable options already chosen by sibling selects within the same grid
+    ['lead', 'follow'].forEach(role => {
+        const selects = Array.from(document.querySelectorAll(`.tiebreak-partner-select[data-role="${role}"]`));
+        const chosen = new Set(selects.map(s => s.value).filter(Boolean));
+        selects.forEach(sel => {
+            Array.from(sel.options).forEach(opt => {
+                if (!opt.value) return;
+                opt.disabled = chosen.has(opt.value) && sel.value !== opt.value;
+            });
+        });
+    });
+}
+
+function updateTiebreakPartnerConfirmState() {
+    const selects = Array.from(document.querySelectorAll('.tiebreak-partner-select'));
+    const allPicked = selects.length > 0 && selects.every(s => s.value);
+    const btn = document.getElementById('tiebreak-confirm-partners');
+    if (btn) btn.disabled = !allPicked;
+}
+
+async function submitTiebreakPartnerSelections() {
+    const leadSelections = {};
+    const followSelections = {};
+    document.querySelectorAll('.tiebreak-partner-select[data-role="lead"]').forEach(sel => {
+        if (sel.value) leadSelections[sel.dataset.name] = sel.value;
+    });
+    document.querySelectorAll('.tiebreak-partner-select[data-role="follow"]').forEach(sel => {
+        if (sel.value) followSelections[sel.dataset.name] = sel.value;
+    });
+
+    try {
+        const resp = await fetch('/api/tiebreak/set_partners', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session_id: sessionId, lead_selections: leadSelections, follow_selections: followSelections }),
+        });
+        const data = await resp.json();
+        tiebreakSubRound = data.sub_round;
+        tiebreakSR1Pairings = data.sr1_pairings;
+        tiebreakSR2Pairings = data.sr2_pairings;
+        renderTiebreakPhase1();
+    } catch (e) {
+        showToast('Failed to submit partner selections', 'error');
+    }
+}
+
+function renderTiebreakPairings(pairings) {
+    return pairings.map(([lead, follow]) =>
+        `<div class="tiebreak-pairing-card">
+            <span class="contestant lead">${lead}</span>
+            <span class="tiebreak-vs">+</span>
+            <span class="contestant follow">${follow}</span>
+        </div>`
+    ).join('');
+}
+
+function renderTiebreakPhase1() {
+    document.getElementById('tiebreak-modal-title').textContent = 'Tie-Break: Sub-Round 1';
+    const body = document.getElementById('tiebreak-modal-body');
+    const footer = document.getElementById('tiebreak-modal-footer');
+    body.innerHTML = `
+        <p class="tiebreak-subtitle">Announce these pairings. Dancers compete — no vote yet.</p>
+        <div class="tiebreak-pairings">${renderTiebreakPairings(tiebreakSR1Pairings)}</div>
+        <p class="tiebreak-note">After all pairs have danced, click "Next" to swap partners.</p>`;
+    footer.innerHTML = '<button id="tiebreak-advance-btn" class="btn primary">Next: Partner Swap →</button>';
+    document.getElementById('tiebreak-advance-btn').addEventListener('click', advanceTiebreakSubRound);
+}
+
+function renderTiebreakPhase2() {
+    document.getElementById('tiebreak-modal-title').textContent = 'Tie-Break: Sub-Round 2 (Swapped Partners)';
+    const body = document.getElementById('tiebreak-modal-body');
+    const footer = document.getElementById('tiebreak-modal-footer');
+    body.innerHTML = `
+        <p class="tiebreak-subtitle">Partners have swapped. Announce these pairings.</p>
+        <div class="tiebreak-pairings">${renderTiebreakPairings(tiebreakSR2Pairings)}</div>
+        <p class="tiebreak-note">After all pairs have danced, proceed to voting.</p>`;
+    footer.innerHTML = '<button id="tiebreak-advance-btn" class="btn primary">Proceed to Voting →</button>';
+    document.getElementById('tiebreak-advance-btn').addEventListener('click', advanceTiebreakSubRound);
+}
+
+async function advanceTiebreakSubRound() {
+    try {
+        const resp = await fetch('/api/tiebreak/advance', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session_id: sessionId }),
+        });
+        const data = await resp.json();
+        tiebreakSubRound = data.sub_round;
+        if (tiebreakSubRound === 2) renderTiebreakPhase2();
+        else if (tiebreakSubRound === 3) renderTiebreakPhase3();
+    } catch (e) {
+        showToast('Failed to advance tie-break', 'error');
+    }
+}
+
+function renderTiebreakPhase3() {
+    document.getElementById('tiebreak-modal-title').textContent = 'Tie-Break: Final Vote';
+    const body = document.getElementById('tiebreak-modal-body');
+    const footer = document.getElementById('tiebreak-modal-footer');
+    tiebreakLeadVotes = {};
+    tiebreakFollowVotes = {};
+
+    body.innerHTML = '<p class="tiebreak-subtitle">Judges vote for the tie-break winner. Tie and No-Contest are not available.</p>';
+
+    const allJudges = [...tiebreakGuestJudges, ...tiebreakContestantJudges];
+
+    if (tiebreakLeadNeeded && tiedLeads.length >= 2) {
+        const section = document.createElement('div');
+        section.className = 'tiebreak-voting-section';
+        section.innerHTML = `<h4>Lead Tie-Break: <span class="contestant lead">${tiedLeads[0]}</span> vs <span class="contestant lead">${tiedLeads[1]}</span></h4>`;
+        const container = document.createElement('div');
+        container.className = 'judges-container';
+        allJudges.forEach(judge => {
+            container.appendChild(createTiebreakJudgeCard(judge, tiebreakGuestJudges.includes(judge), 'tb-lead', tiedLeads[0], tiedLeads[1]));
+        });
+        section.appendChild(container);
+        body.appendChild(section);
+    }
+
+    if (tiebreakFollowNeeded && tiedFollows.length >= 2) {
+        if (tiebreakLeadNeeded) {
+            const hr = document.createElement('hr');
+            hr.className = 'tiebreak-section-divider';
+            body.appendChild(hr);
+        }
+        const section = document.createElement('div');
+        section.className = 'tiebreak-voting-section';
+        section.innerHTML = `<h4>Follow Tie-Break: <span class="contestant follow">${tiedFollows[0]}</span> vs <span class="contestant follow">${tiedFollows[1]}</span></h4>`;
+        const container = document.createElement('div');
+        container.className = 'judges-container';
+        allJudges.forEach(judge => {
+            container.appendChild(createTiebreakJudgeCard(judge, tiebreakGuestJudges.includes(judge), 'tb-follow', tiedFollows[0], tiedFollows[1]));
+        });
+        section.appendChild(container);
+        body.appendChild(section);
+    }
+
+    footer.innerHTML = '<button id="tiebreak-submit-votes" class="btn primary" disabled>Submit Tie-Break Votes</button>';
+    document.getElementById('tiebreak-submit-votes').addEventListener('click', submitTiebreakVotes);
+}
+
+function createTiebreakJudgeCard(judgeName, isGuest, voteType, name1, name2) {
+    const row = document.createElement('div');
+    row.className = 'judge-row';
+
+    const avatar = document.createElement('div');
+    avatar.className = 'avatar';
+    avatar.textContent = judgeName.split(/\s+/).map(w => w[0] || '').join('').toUpperCase().slice(0, 2);
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'judge-name';
+    nameEl.textContent = judgeName + (isGuest ? ' (Guest)' : '');
+
+    const chips = document.createElement('div');
+    chips.className = 'vote-chips';
+
+    function onChip(chip, val) {
+        chips.querySelectorAll('.vote-chip').forEach(c => c.classList.remove('selected'));
+        chip.classList.add('selected');
+        row.classList.add('voted');
+        avatar.classList.add('voted');
+        if (voteType === 'tb-lead') tiebreakLeadVotes[judgeName] = val;
+        else tiebreakFollowVotes[judgeName] = val;
+        updateTiebreakSubmitState();
+    }
+
+    const chip1 = document.createElement('button');
+    chip1.className = 'vote-chip';
+    chip1.textContent = name1;
+    chip1.addEventListener('click', () => onChip(chip1, 1));
+
+    const chip2 = document.createElement('button');
+    chip2.className = 'vote-chip';
+    chip2.textContent = name2;
+    chip2.addEventListener('click', () => onChip(chip2, 2));
+
+    chips.appendChild(chip1);
+    chips.appendChild(chip2);
+    row.appendChild(avatar);
+    row.appendChild(nameEl);
+    row.appendChild(chips);
+    return row;
+}
+
+function updateTiebreakSubmitState() {
+    const btn = document.getElementById('tiebreak-submit-votes');
+    if (!btn) return;
+    const allJudges = [...tiebreakGuestJudges, ...tiebreakContestantJudges];
+    const leadOk = !tiebreakLeadNeeded || allJudges.every(j => tiebreakLeadVotes[j] !== undefined);
+    const followOk = !tiebreakFollowNeeded || allJudges.every(j => tiebreakFollowVotes[j] !== undefined);
+    btn.disabled = !(leadOk && followOk);
+}
+
+async function submitTiebreakVotes() {
+    const allJudges = [...tiebreakGuestJudges, ...tiebreakContestantJudges];
+    const leadVotesArray = tiebreakLeadNeeded ? allJudges.filter(j => tiebreakLeadVotes[j] !== undefined).map(j => [j, tiebreakLeadVotes[j]]) : [];
+    const followVotesArray = tiebreakFollowNeeded ? allJudges.filter(j => tiebreakFollowVotes[j] !== undefined).map(j => [j, tiebreakFollowVotes[j]]) : [];
+
+    try {
+        const resp = await fetch('/api/tiebreak/vote', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session_id: sessionId, lead_votes: leadVotesArray, follow_votes: followVotesArray }),
+        });
+        const data = await resp.json();
+        renderTiebreakResults(data);
+    } catch (e) {
+        showToast('Failed to submit tie-break votes', 'error');
+    }
+}
+
+function renderTiebreakResults(data) {
+    document.getElementById('tiebreak-modal-title').textContent = 'Tie-Break Results';
+    const body = document.getElementById('tiebreak-modal-body');
+    const footer = document.getElementById('tiebreak-modal-footer');
+
+    let html = '<div class="tiebreak-results">';
+    if (data.lead_result) {
+        html += `<div class="tiebreak-winner-banner">
+            <span class="tiebreak-role-label">Lead Winner</span>
+            <span class="tiebreak-winner-name">${data.lead_result.winner} 👑</span>
+        </div>`;
+    }
+    if (data.follow_result) {
+        html += `<div class="tiebreak-winner-banner">
+            <span class="tiebreak-role-label">Follow Winner</span>
+            <span class="tiebreak-winner-name">${data.follow_result.winner} 👑</span>
+        </div>`;
+    }
+    html += '</div>';
+    body.innerHTML = html;
+
+    footer.innerHTML = '<button id="tiebreak-view-results" class="btn primary">View Final Results</button>';
+    document.getElementById('tiebreak-view-results').addEventListener('click', finalizeTiebreakAndShowResults);
+}
+
+async function finalizeTiebreakAndShowResults() {
+    try {
+        const resp = await fetch('/api/tiebreak/finalize', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session_id: sessionId }),
+        });
+        const data = await resp.json();
+        document.getElementById('tiebreak-modal').classList.add('hidden');
+        tiebreakActive = false;
+        if (!data.initial_leads || !data.initial_follows) {
+            data.initial_leads = initialLeads;
+            data.initial_follows = initialFollows;
+        }
+        displayResults(data);
+    } catch (e) {
+        showToast('Failed to finalize tie-break', 'error');
+    }
+}
 
 function pickNextUnusedTrack() {
     const unused = playlistTracks.filter(t => t && t.id && !usedTrackIds.has(t.id));


### PR DESCRIPTION
## Summary

- Implements a full tie-break flow triggered when \"End Battle Early\" is selected and contestants are tied on points
- Tie-break runs up to 3 sub-rounds (partner selection → SR1 → SR2 → judge vote) with recursive rounds until a clear winner emerges
- Supports asymmetric ties (leads only, follows only, or both), N-way ties, and recursive re-ties
- Display (projector) mode shows the active tie-break phase, pairings, and winner banners in real time via the existing polling loop
- Final results screen: tie-break round appears in the round history accordion with a distinct badge and winner highlights; battle graphic badges land on the tied contestants (not the dangling pre-tie-break round); display mode shows only the battle graphic full-screen

## What's included

**Core logic (`game_logic.py`)**
- `detect_tiebreak_needs` / `start_tiebreak` / `set_tiebreak_partner_selections` / `advance_tiebreak_sub_round` / `judge_tiebreak` / `finalize_tiebreak_results`
- Symmetric partner selection for both leads and follows
- N-way name-based voting with recursive narrowing until resolved
- Snapshot of original tied contestants for battle graphic attribution

**Backend (`web/app.py`)**
- `/api/tiebreak/set_partners`, `/api/tiebreak/advance`, `/api/tiebreak/vote`, `/api/tiebreak/finalize` endpoints
- `serialize_state()` exposes full tie-break state for display mode polling
- `_format_end_game_results` replaces the incomplete pre-tie-break round with a synthetic tie-break entry for the round history and battle graphic

**Frontend (`web/js/app.js`, `web/index.html`, `web/css/styles.css`)**
- Admin tie-break modal: partner selection dropdowns, SR1/SR2 pairing cards, per-judge voting chips, vote-tally screen with recursive "Continue" flow
- `renderDisplayModeTiebreak()` — read-only projector view for each phase; hides resolved roles from the contestants section
- Round history accordion: tie-break rounds render with a badge, role labels, vs separators, and winner trophy; accordion toggle bug fixed
- Battle graphic: branches on `r.tiebreak` flag to badge all original tied contestants
- Display mode results screen: hides leaderboard/history/actions, expands battle graphic to full viewport; `.active` scoping prevents dual-screen flex conflict

**Tests (`tiebreak_tests.py`)**
- 30 unit tests across 7 test classes covering all tie-break methods

## Test plan

- [ ] End battle early with leads tied → tie-break modal appears with correct contestants
- [ ] End battle early with follows tied only → symmetric follow partner selection works
- [ ] End battle early with both roles tied → both roles go through tie-break
- [ ] Vote produces a recursive tie → "still tied" screen appears, another round starts
- [ ] Vote resolves → winner banners shown, finalize promotes winners to results
- [ ] Display mode tab updates within 3 s at each tie-break phase transition
- [ ] Resolved role (e.g. lead winner set) no longer appears in display contestants section during recursive follow round
- [ ] Final results: tie-break round shows in round history with badge and winners
- [ ] Final results: battle graphic badges on tied contestants, not pre-tie-break pair
- [ ] Display mode results screen: only battle graphic shown, fills viewport
- [ ] Normal (non-tie-break) battle flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)