### PR TITLE
feat(results): add 9:16 social image export button

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -562,6 +562,10 @@ def judge_leads():
     if song_info:
         game.current_round.song_info = song_info
 
+    # Convert dict format [{"judge": name, "vote": val}] → tuple format [(name, val)]
+    if votes and isinstance(votes[0], dict):
+        votes = [(v["judge"], v["vote"]) for v in votes]
+
     # Process votes and determine winner
     result = game.judge_round(game.pair_1[0], game.pair_2[0], "lead", votes)
 
@@ -594,6 +598,10 @@ def judge_follows():
     # Update song info in the current round if not already set
     if song_info and not hasattr(game.current_round, "song_info"):
         game.current_round.song_info = song_info
+
+    # Convert dict format [{"judge": name, "vote": val}] → tuple format [(name, val)]
+    if votes and isinstance(votes[0], dict):
+        votes = [(v["judge"], v["vote"]) for v in votes]
 
     # Process votes and determine winner
     result = game.judge_round(game.pair_1[1], game.pair_2[1], "follow", votes)
@@ -658,6 +666,12 @@ def judge_combined():
             return expanded
         except Exception:
             return votes_list
+
+    # Convert dict format [{"judge": name, "vote": val}] → tuple format [(name, val)]
+    if lead_votes and isinstance(lead_votes[0], dict):
+        lead_votes = [(v["judge"], v["vote"]) for v in lead_votes]
+    if follow_votes and isinstance(follow_votes[0], dict):
+        follow_votes = [(v["judge"], v["vote"]) for v in follow_votes]
 
     # Expand votes when needed
     lead_votes_effective = expand_with_mock_contestant_judges(lead_votes)

--- a/web/app.py
+++ b/web/app.py
@@ -562,10 +562,6 @@ def judge_leads():
     if song_info:
         game.current_round.song_info = song_info
 
-    # Convert dict format [{"judge": name, "vote": val}] → tuple format [(name, val)]
-    if votes and isinstance(votes[0], dict):
-        votes = [(v["judge"], v["vote"]) for v in votes]
-
     # Process votes and determine winner
     result = game.judge_round(game.pair_1[0], game.pair_2[0], "lead", votes)
 
@@ -598,10 +594,6 @@ def judge_follows():
     # Update song info in the current round if not already set
     if song_info and not hasattr(game.current_round, "song_info"):
         game.current_round.song_info = song_info
-
-    # Convert dict format [{"judge": name, "vote": val}] → tuple format [(name, val)]
-    if votes and isinstance(votes[0], dict):
-        votes = [(v["judge"], v["vote"]) for v in votes]
 
     # Process votes and determine winner
     result = game.judge_round(game.pair_1[1], game.pair_2[1], "follow", votes)
@@ -666,12 +658,6 @@ def judge_combined():
             return expanded
         except Exception:
             return votes_list
-
-    # Convert dict format [{"judge": name, "vote": val}] → tuple format [(name, val)]
-    if lead_votes and isinstance(lead_votes[0], dict):
-        lead_votes = [(v["judge"], v["vote"]) for v in lead_votes]
-    if follow_votes and isinstance(follow_votes[0], dict):
-        follow_votes = [(v["judge"], v["vote"]) for v in follow_votes]
 
     # Expand votes when needed
     lead_votes_effective = expand_with_mock_contestant_judges(lead_votes)

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
     <title>Hustle n' Tussle - Dance Competition</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Anton&family=DM+Mono:wght@500&family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=Permanent+Marker&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@500&amp;family=DM+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=Space+Grotesk:wght@500;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css?v={{ config.ASSET_VERSION }}">
     <style>
         /* Year-to-date stats page + modals (scoped, builds on existing classes) */

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,7 @@
     <title>Hustle n' Tussle - Dance Competition</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@500&amp;family=DM+Sans:wght@400;500;600;700&amp;family=Inter:wght@400;500;600;700;800&amp;family=Space+Grotesk:wght@500;700&amp;display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=DM+Mono:wght@500&family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=Permanent+Marker&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css?v={{ config.ASSET_VERSION }}">
 </head>
 <body>

--- a/web/index.html
+++ b/web/index.html
@@ -527,6 +527,7 @@
             <div class="results-actions">
                 <button id="back-to-home-from-results" class="btn primary">Back to Home</button>
                 <button id="download-battle-data" class="btn secondary">Download Battle Data</button>
+                <button id="export-social-image" class="btn secondary">Share Results (9:16)</button>
             </div>
         </div>
     </div>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3321,66 +3321,38 @@ async function exportSocialImage() {
     };
 
     // --- Header ---
-    const now = new Date();
-    const TITLE_SIZE = 96;
-    const titleY = 12 + 52 + Math.round(TITLE_SIZE * 0.78); // baseline ≈ 151
+    const TITLE_SIZE = 88;
+    const titleY = 12 + 60 + Math.round(TITLE_SIZE * 0.78); // baseline ≈ 141
     ctx.textAlign = 'center';
     ctx.fillStyle = C.ink;
     ctx.font = `${TITLE_SIZE}px "Permanent Marker","Knewave",cursive`;
     ctx.fillText("Hustle n' Tussle", W / 2, titleY);
 
-    // Gold rule directly below title
-    const ruleY = titleY + 14;
+    const EDITION_SIZE = 38;
+    const editionY = titleY + Math.round(TITLE_SIZE * 0.22) + 18 + EDITION_SIZE; // gap 18
+    const now = new Date();
+    const editionText = `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
+    ctx.fillStyle = C.gray;
+    ctx.font = `500 ${EDITION_SIZE}px "Inter","DM Sans",sans-serif`;
+    ctx.fillText(editionText, W / 2, editionY);
+
+    // Gold brush underline below edition
+    const edW = ctx.measureText(editionText).width;
+    const ulY = editionY + 10;
     ctx.strokeStyle = C.gold;
-    ctx.lineWidth = 5;
+    ctx.lineWidth = 4;
     ctx.lineCap = 'round';
     ctx.beginPath();
-    ctx.moveTo(W / 2 - 320, ruleY);
-    ctx.quadraticCurveTo(W / 2, ruleY + 5, W / 2 + 320, ruleY + 1);
+    ctx.moveTo(W / 2 - edW / 2, ulY);
+    ctx.quadraticCurveTo(W / 2 - edW / 4, ulY + 6, W / 2, ulY + 3);
+    ctx.quadraticCurveTo(W / 2 + edW / 4, ulY, W / 2 + edW / 2, ulY + 5);
     ctx.stroke();
 
-    // Date sticky-note tag — top right, slightly rotated
-    ctx.save();
-    ctx.translate(W - 72, titleY - 40);
-    ctx.rotate(0.09);
-    const tagW = 148, tagH = 96;
-    _rrect(ctx, -tagW / 2, -tagH / 2, tagW, tagH, 8);
-    ctx.fillStyle = C.gold;
-    ctx.fill();
-    ctx.fillStyle = C.ink;
-    ctx.font = `32px "Permanent Marker",cursive`;
-    ctx.textAlign = 'center';
-    ctx.fillText(`${now.toLocaleDateString('en-US', { month: 'short' })} ${now.getDate()},`, 0, -10);
-    ctx.fillText(`${now.getFullYear()}.`, 0, 30);
-    ctx.restore();
-
-    // Black brush-band for edition
-    const EDITION_SIZE = 42;
-    const bandGap = 18; // gap from rule to band
-    const bandH = EDITION_SIZE + 28;
-    const bandY = ruleY + bandGap;
-    const bandMid = bandY + bandH / 2;
-    // Rough brush-stroke shape
-    ctx.fillStyle = C.ink;
-    ctx.beginPath();
-    ctx.moveTo(24, bandY + 3);
-    ctx.quadraticCurveTo(W / 2, bandY - 5, W - 24, bandY + 6);
-    ctx.quadraticCurveTo(W - 18, bandMid, W - 24, bandY + bandH - 4);
-    ctx.quadraticCurveTo(W / 2, bandY + bandH + 6, 24, bandY + bandH - 2);
-    ctx.quadraticCurveTo(18, bandMid, 24, bandY + 3);
-    ctx.fill();
-    // Edition text in gold on the band
-    const editionText = `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
-    ctx.fillStyle = C.gold;
-    ctx.font = `${EDITION_SIZE}px "Permanent Marker",cursive`;
-    ctx.textAlign = 'center';
-    ctx.fillText(editionText, W / 2, bandY + bandH * 0.68);
-
-    // Judges line below the band
-    let contentStartY = bandY + bandH + 16 + 32; // no judges
+    // Judges line (8 px below underline)
+    let contentStartY = ulY + 8 + 32; // no judges: 32px gap to cards
     if (resultsGuestJudges.length > 0) {
-        const JUDGES_SIZE = 34;
-        const judgesY = bandY + bandH + 16 + JUDGES_SIZE;
+        const JUDGES_SIZE = 36;
+        const judgesY = ulY + 8 + JUDGES_SIZE;
         ctx.fillStyle = C.gray;
         ctx.font = `500 ${JUDGES_SIZE}px "Inter","DM Sans",sans-serif`;
         ctx.fillText(
@@ -3454,14 +3426,11 @@ async function exportSocialImage() {
         ctx.fillStyle = C.ink;
         ctx.fillRect(CARD_X, startY, CARD_W, CARD_HEADER_H);
 
-        // Crown icon + section label in header
-        const HEADER_CROWN = 26;
-        const crownHCX = innerLeft + HEADER_CROWN * 0.7;
-        drawCrown(crownHCX, startY + CARD_HEADER_H / 2, HEADER_CROWN);
+        // Section label — Anton, white, ALL CAPS
         ctx.fillStyle = '#FFFFFF';
         ctx.font = `normal 56px "Anton","Bebas Neue","Space Grotesk",sans-serif`;
         ctx.textAlign = 'left';
-        ctx.fillText(label.toUpperCase(), innerLeft + HEADER_CROWN * 1.4 + 14, startY + CARD_HEADER_H - 14);
+        ctx.fillText(label.toUpperCase(), innerLeft, startY + CARD_HEADER_H - 14);
 
         // Contestant rows
         const rowsStartY = startY + CARD_HEADER_H;
@@ -3533,7 +3502,7 @@ async function exportSocialImage() {
                 ctx.stroke();
 
                 // Round number
-                ctx.fillStyle = info.win ? '#FFFFFF' : C.ink;
+                ctx.fillStyle = info.win ? '#FFFFFF' : C.gray;
                 ctx.font = `700 ${tokenFontSize}px "Inter","DM Mono",monospace`;
                 ctx.textAlign = 'center';
                 ctx.fillText(String(info.round), cx, tokenCY + tokenFontSize * 0.37);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3212,189 +3212,250 @@ function _rrect(ctx, x, y, w, h, r) {
 }
 
 async function exportSocialImage() {
-    const W = 1080;
-    const H = 1920;
-    const PAD = 50;
-
+    const W = 1080, H = 1920;
     await document.fonts.ready;
 
     const canvas = document.createElement('canvas');
-    canvas.width = W;
-    canvas.height = H;
+    canvas.width = W; canvas.height = H;
     const ctx = canvas.getContext('2d');
 
-    // Background — white
-    ctx.fillStyle = '#ffffff';
+    // Design tokens
+    const C = {
+        ink:      '#111111',
+        paper:    '#F8F7F4',
+        paperAlt: '#EFEDE9',
+        gray:     '#808080',
+        border:   '#D4D4D4',
+        gold:     '#F5B400',
+    };
+
+    // Background (paper, never pure white)
+    ctx.fillStyle = C.paper;
     ctx.fillRect(0, 0, W, H);
 
-    // Top accent bar — black
-    ctx.fillStyle = '#111111';
+    // Top accent bar
+    ctx.fillStyle = C.ink;
     ctx.fillRect(0, 0, W, 12);
 
+    // Custom crown path — gold, drawn at center (cx, cy), given height `size`
+    const drawCrown = (cx, cy, size) => {
+        const w = size * 1.4;
+        ctx.fillStyle = C.gold;
+        ctx.beginPath();
+        ctx.moveTo(cx - w / 2,    cy + size * 0.42);
+        ctx.lineTo(cx - w / 2,    cy - size * 0.08);
+        ctx.lineTo(cx - w * 0.15, cy + size * 0.22);
+        ctx.lineTo(cx,            cy - size * 0.52);
+        ctx.lineTo(cx + w * 0.15, cy + size * 0.22);
+        ctx.lineTo(cx + w / 2,    cy - size * 0.08);
+        ctx.lineTo(cx + w / 2,    cy + size * 0.42);
+        ctx.closePath();
+        ctx.fill();
+        // Dots at the three tips
+        const dr = size * 0.11;
+        [[cx - w / 2, cy - size * 0.08], [cx, cy - size * 0.52], [cx + w / 2, cy - size * 0.08]].forEach(([dx, dy]) => {
+            ctx.beginPath();
+            ctx.arc(dx, dy - dr * 0.7, dr, 0, Math.PI * 2);
+            ctx.fill();
+        });
+    };
+
     // --- Header ---
+    const TITLE_SIZE = 88;
+    const titleY = 12 + 60 + Math.round(TITLE_SIZE * 0.78); // baseline ≈ 141
     ctx.textAlign = 'center';
-    ctx.fillStyle = '#000000';
-    ctx.font = 'bold 78px "Space Grotesk","DM Sans",sans-serif';
-    ctx.fillText("Hustle n' Tussle", W / 2, 130);
+    ctx.fillStyle = C.ink;
+    ctx.font = `${TITLE_SIZE}px "Permanent Marker","Knewave",cursive`;
+    ctx.fillText("Hustle n' Tussle", W / 2, titleY);
 
+    const EDITION_SIZE = 38;
+    const editionY = titleY + Math.round(TITLE_SIZE * 0.22) + 18 + EDITION_SIZE; // gap 18
     const now = new Date();
-    const monthStr = now.toLocaleDateString('en-US', { month: 'long' });
-    const yearStr = now.getFullYear();
-    ctx.fillStyle = '#888888';
-    ctx.font = '400 38px "Inter","DM Sans",sans-serif';
-    ctx.fillText(`${monthStr} Edition (${yearStr})`, W / 2, 200);
+    const editionText = `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
+    ctx.fillStyle = C.gray;
+    ctx.font = `500 ${EDITION_SIZE}px "Inter","DM Sans",sans-serif`;
+    ctx.fillText(editionText, W / 2, editionY);
 
+    // Gold brush underline below edition
+    const edW = ctx.measureText(editionText).width;
+    const ulY = editionY + 10;
+    ctx.strokeStyle = C.gold;
+    ctx.lineWidth = 4;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(W / 2 - edW / 2, ulY);
+    ctx.quadraticCurveTo(W / 2 - edW / 4, ulY + 6, W / 2, ulY + 3);
+    ctx.quadraticCurveTo(W / 2 + edW / 4, ulY, W / 2 + edW / 2, ulY + 5);
+    ctx.stroke();
+
+    // Judges line (8 px below underline)
+    let contentStartY = ulY + 8 + 32; // no judges: 32px gap to cards
     if (resultsGuestJudges.length > 0) {
-        const judgeLabel = resultsGuestJudges.length === 1 ? 'Judge' : 'Judges';
-        ctx.fillStyle = '#222222';
-        ctx.font = '600 40px "Space Grotesk","DM Sans",sans-serif';
-        ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 258);
+        const JUDGES_SIZE = 36;
+        const judgesY = ulY + 8 + JUDGES_SIZE;
+        ctx.fillStyle = C.gray;
+        ctx.font = `500 ${JUDGES_SIZE}px "Inter","DM Sans",sans-serif`;
+        ctx.fillText(
+            `${resultsGuestJudges.length === 1 ? 'Judge' : 'Judges'}: ${resultsGuestJudges.join(', ')}`,
+            W / 2, judgesY
+        );
+        contentStartY = judgesY + 32;
     }
 
+    // --- Data ---
     const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));
     const sortedFollows = [...currentFollows].sort((a, b) => (b.points || 0) - (a.points || 0));
-
-    const contentStartY = 300;
-
-    // --- Battle Graphic ---
     const leadsOrder = resultsInitialLeads.length ? resultsInitialLeads : sortedLeads.map(l => l.name);
     const followsOrder = resultsInitialFollows.length ? resultsInitialFollows : sortedFollows.map(f => f.name);
-    const numRounds = resultsNumRounds || 0;
 
-    // Layout: two card sections (Leads then Follows)
-    const CARD_HEADER_H = 76;   // dark strip at top of each card
-    const CARD_PAD_BOTTOM = 16; // padding below last row inside card
-    const SECTION_GAP = 20;
-    const FOOTER_H = 40;
-    const availForRows = (H - FOOTER_H) - contentStartY
-        - 2 * (CARD_HEADER_H + CARD_PAD_BOTTOM)
-        - SECTION_GAP;
-    const maxDancers = Math.max(leadsOrder.length, followsOrder.length);
+    // --- Layout constants (from design system) ---
+    const CARD_X = 24;
+    const CARD_W = W - 48;
+    const CARD_PAD_H = 24;    // horizontal inner padding
+    const CARD_HEADER_H = 72;
+    const ROW_H = 72;
+    const CARD_PAD_BOTTOM = 24;
+    const BETWEEN_CARDS = 32;
+    const CARD_RADIUS = 20;
+    const TOKEN_SIZE = 44;
+    const TOKEN_GAP = 8;
+    const CROWN_SIZE = 18;
 
-    // Badge sizing: fit all rounds on a single horizontal line per row
-    const rankW = 44;
-    const nameAreaW = 260;
-    const badgeStartX = PAD + rankW + nameAreaW + 24;
-    const badgeAreaW = W - PAD - badgeStartX;
-    const badgeGap = 4;
+    const innerLeft = CARD_X + CARD_PAD_H;
+    const innerRight = CARD_X + CARD_W - CARD_PAD_H;
 
-    // Use the most rounds any individual dancer competed in (not total game rounds)
-    // so the badge row fills the full width for the most active dancer.
+    // Row sub-layout: Rank | gap | Name | gap | Tokens (right portion)
+    const RANK_W = 36;
+    const RANK_NAME_GAP = 16;
+    const NAME_W = 220;
+    const NAME_BADGE_GAP = 24;
+    const badgeStartX = innerLeft + RANK_W + RANK_NAME_GAP + NAME_W + NAME_BADGE_GAP;
+    const badgeAreaW = innerRight - badgeStartX;
+
+    // Token sizing: 44 px target, scale down only when necessary
     const allRoundCounts = [
         ...[...leadsOrder].map(n => (resultsLeadMap.get(n) || []).length),
         ...[...followsOrder].map(n => (resultsFollowMap.get(n) || []).length),
     ];
     const maxRoundsPerDancer = Math.max(...allRoundCounts, 1);
-    const badgeSizeFromRounds = Math.floor((badgeAreaW + badgeGap) / maxRoundsPerDancer) - badgeGap;
+    const tokenSizeFromW = Math.floor((badgeAreaW + TOKEN_GAP) / maxRoundsPerDancer) - TOKEN_GAP;
+    const tokenSize = Math.max(20, Math.min(TOKEN_SIZE, tokenSizeFromW));
+    const tokenFontSize = Math.max(10, Math.round(tokenSize * 0.46));
 
-    // rowH fills all available vertical space; badgeSize is the smaller of the two constraints
-    const maxRowHFromSpace = maxDancers > 0 ? Math.floor(availForRows / (2 * maxDancers)) : 70;
-    const rowH = Math.max(36, maxRowHFromSpace);
-    const badgeSize = Math.max(16, Math.min(rowH - 18, badgeSizeFromRounds));
-    const bFontSize = Math.max(9, Math.round(badgeSize * 0.52));
-    const nameFontSize = Math.max(20, Math.min(44, rowH - 26));
-    const rankFontSize = Math.max(16, nameFontSize - 4);
+    const NAME_SIZE = 34;
+    const RANK_SIZE = 28;
 
+    // --- Draw one card section ---
     const drawSection = (order, map, topName, label, startY) => {
-        const CARD_RADIUS = 20;
-        const cardX = PAD - 12;
-        const cardW = W - 2 * (PAD - 12);
-        const cardH = CARD_HEADER_H + order.length * rowH + CARD_PAD_BOTTOM;
+        const cardH = CARD_HEADER_H + order.length * ROW_H + CARD_PAD_BOTTOM;
 
-        // Card background (light)
-        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
-        ctx.fillStyle = '#f4f4f4';
+        // Card base (paper background + border)
+        _rrect(ctx, CARD_X, startY, CARD_W, cardH, CARD_RADIUS);
+        ctx.fillStyle = C.paper;
         ctx.fill();
-
-        // Dark header strip — clipped to card shape so top corners are rounded
-        ctx.save();
-        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
-        ctx.clip();
-        ctx.fillStyle = '#111111';
-        ctx.fillRect(cardX, startY, cardW, CARD_HEADER_H);
-        ctx.restore();
-
-        // Card border
-        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
-        ctx.strokeStyle = 'rgba(0,0,0,0.1)';
-        ctx.lineWidth = 1.5;
+        ctx.strokeStyle = C.border;
+        ctx.lineWidth = 1;
         ctx.stroke();
 
-        // Section label — white bold uppercase in dark strip
-        ctx.fillStyle = '#ffffff';
-        ctx.font = `bold 52px "Space Grotesk","DM Sans",sans-serif`;
+        // Everything inside the card is clipped to its rounded shape
+        ctx.save();
+        _rrect(ctx, CARD_X, startY, CARD_W, cardH, CARD_RADIUS);
+        ctx.clip();
+
+        // Dark header strip
+        ctx.fillStyle = C.ink;
+        ctx.fillRect(CARD_X, startY, CARD_W, CARD_HEADER_H);
+
+        // Section label — Anton, white, ALL CAPS
+        ctx.fillStyle = '#FFFFFF';
+        ctx.font = `normal 56px "Anton","Bebas Neue","Space Grotesk",sans-serif`;
         ctx.textAlign = 'left';
-        ctx.fillText(label.toUpperCase(), cardX + 24, startY + CARD_HEADER_H - 18);
+        ctx.fillText(label.toUpperCase(), innerLeft, startY + CARD_HEADER_H - 14);
 
+        // Contestant rows
         const rowsStartY = startY + CARD_HEADER_H;
-
         order.forEach((name, idx) => {
-            const rowY = rowsStartY + idx * rowH;
+            const rowY = rowsStartY + idx * ROW_H;
             const isTop = name === topName;
-            const textBaseY = rowY + rowH * 0.64;
+            const baseY = rowY + Math.round(ROW_H * 0.625);
 
-            // Alternating row tint
-            if (idx % 2 === 0) {
-                ctx.fillStyle = 'rgba(0,0,0,0.04)';
-                ctx.fillRect(PAD - 8, rowY + 1, W - (PAD - 8) * 2, rowH - 1);
+            // Alternating row background (Paper / PaperAlt)
+            ctx.fillStyle = idx % 2 === 0 ? C.paper : C.paperAlt;
+            ctx.fillRect(CARD_X, rowY, CARD_W, ROW_H);
+
+            // Row separator (almost invisible)
+            if (idx > 0) {
+                ctx.strokeStyle = 'rgba(0,0,0,0.06)';
+                ctx.lineWidth = 1;
+                ctx.beginPath();
+                ctx.moveTo(innerLeft, rowY);
+                ctx.lineTo(innerRight, rowY);
+                ctx.stroke();
             }
 
-            // Rank
-            ctx.fillStyle = '#aaaaaa';
-            ctx.font = `400 ${rankFontSize}px "DM Mono",monospace`;
+            // Rank number
+            ctx.fillStyle = C.gray;
+            ctx.font = `400 ${RANK_SIZE}px "Inter","DM Sans",sans-serif`;
             ctx.textAlign = 'left';
-            ctx.fillText((idx + 1) + '.', PAD, textBaseY);
+            ctx.fillText(`${idx + 1}.`, innerLeft, baseY);
 
-            // Name + crown — clipped to nameAreaW so crown never bleeds into badge area
+            // Name (clipped to name column so it never bleeds into tokens)
+            const nameX = innerLeft + RANK_W + RANK_NAME_GAP;
             ctx.save();
             ctx.beginPath();
-            ctx.rect(PAD + rankW, rowY, nameAreaW, rowH);
+            ctx.rect(nameX, rowY, NAME_W, ROW_H);
             ctx.clip();
-            const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
-            const displayName = name.length > maxChars ? name.slice(0, maxChars - 1) + '…' : name;
-            ctx.fillStyle = isTop ? '#111111' : '#555555';
-            ctx.font = isTop
-                ? `bold ${nameFontSize}px "DM Sans",sans-serif`
-                : `400 ${nameFontSize}px "DM Sans",sans-serif`;
-            ctx.fillText(displayName, PAD + rankW, textBaseY);
-            if (isTop) {
-                const nameW2 = ctx.measureText(displayName).width;
-                ctx.font = `${nameFontSize}px serif`;
-                ctx.fillText('👑', PAD + rankW + nameW2 + 5, textBaseY);
-            }
+            ctx.fillStyle = isTop ? C.ink : '#444444';
+            ctx.font = `${isTop ? 700 : 600} ${NAME_SIZE}px "Inter","DM Sans",sans-serif`;
+            ctx.textAlign = 'left';
+            ctx.fillText(name, nameX, baseY);
             ctx.restore();
 
-            // Round badges — one row of circles
-            const rounds = (map.get(name) || []).slice().sort((a, b) => a.round - b.round);
-            const badgeCY = rowY + rowH / 2;
-            rounds.forEach((info, bi) => {
-                const cx = badgeStartX + bi * (badgeSize + badgeGap) + badgeSize / 2;
-                const cy = badgeCY;
-                const r = badgeSize / 2;
+            // Crown icon (custom path, gold) placed after name if champion
+            if (isTop) {
+                ctx.font = `700 ${NAME_SIZE}px "Inter","DM Sans",sans-serif`;
+                const nameTextW = ctx.measureText(name).width;
+                const crownCX = nameX + nameTextW + 12 + CROWN_SIZE * 0.7;
+                if (crownCX + CROWN_SIZE < badgeStartX) {
+                    drawCrown(crownCX, baseY - NAME_SIZE * 0.38, CROWN_SIZE);
+                }
+            }
 
+            // Round tokens
+            const rounds = (map.get(name) || []).slice().sort((a, b) => a.round - b.round);
+            const tokenCY = rowY + ROW_H / 2;
+            rounds.forEach((info, bi) => {
+                const cx = badgeStartX + bi * (tokenSize + TOKEN_GAP) + tokenSize / 2;
+                const r = tokenSize / 2;
+
+                // Token fill
                 ctx.beginPath();
-                ctx.arc(cx, cy, r, 0, Math.PI * 2);
-                ctx.fillStyle = info.win ? '#111111' : '#f0f0f0';
+                ctx.arc(cx, tokenCY, r, 0, Math.PI * 2);
+                ctx.fillStyle = info.win ? C.ink : C.paper;
                 ctx.fill();
 
+                // Token border
                 ctx.beginPath();
-                ctx.arc(cx, cy, r - 0.75, 0, Math.PI * 2);
-                ctx.strokeStyle = info.win ? '#333333' : 'rgba(0,0,0,0.2)';
+                ctx.arc(cx, tokenCY, r - 1, 0, Math.PI * 2);
+                ctx.strokeStyle = info.win ? C.ink : C.border;
                 ctx.lineWidth = 1.5;
                 ctx.stroke();
 
-                ctx.fillStyle = info.win ? '#ffffff' : '#aaaaaa';
-                ctx.font = `bold ${bFontSize}px "DM Mono",monospace`;
+                // Round number
+                ctx.fillStyle = info.win ? '#FFFFFF' : C.gray;
+                ctx.font = `700 ${tokenFontSize}px "Inter","DM Mono",monospace`;
                 ctx.textAlign = 'center';
-                ctx.fillText(String(info.round), cx, cy + bFontSize * 0.37);
+                ctx.fillText(String(info.round), cx, tokenCY + tokenFontSize * 0.37);
             });
         });
 
-        return rowsStartY + order.length * rowH + CARD_PAD_BOTTOM;
+        ctx.restore(); // end card clip
+
+        return rowsStartY + order.length * ROW_H + CARD_PAD_BOTTOM;
     };
 
     const leadsEnd = drawSection(leadsOrder, resultsLeadMap, resultsTopLeadName, 'Leads', contentStartY);
-    drawSection(followsOrder, resultsFollowMap, resultsTopFollowName, 'Follows', leadsEnd + SECTION_GAP);
+    drawSection(followsOrder, resultsFollowMap, resultsTopFollowName, 'Follows', leadsEnd + BETWEEN_CARDS);
 
     canvas.toBlob(blob => {
         if (!blob) { showToast('Failed to generate image', 'error'); return; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2613,6 +2613,10 @@ async function displayResults(data) {
     if (leadGraphic) leadGraphic.innerHTML = '';
     if (followGraphic) followGraphic.innerHTML = '';
     
+    // Sync globals so exportSocialImage() has current data
+    currentLeads = data.leads || [];
+    currentFollows = data.follows || [];
+
     // Always use the initial order from the server response
     const initialLeadsData = data.initial_leads || [];
     const initialFollowsData = data.initial_follows || [];

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3336,42 +3336,49 @@ async function exportSocialImage() {
     const leadsOrder = resultsInitialLeads.length ? resultsInitialLeads : sortedLeads.map(l => l.name);
     const followsOrder = resultsInitialFollows.length ? resultsInitialFollows : sortedFollows.map(f => f.name);
 
-    // --- Layout constants (from design system) ---
+    // --- Layout constants ---
     const CARD_X = 24;
     const CARD_W = W - 48;
-    const CARD_PAD_H = 24;    // horizontal inner padding
+    const CARD_PAD_H = 24;
     const CARD_HEADER_H = 72;
-    const ROW_H = 72;
     const CARD_PAD_BOTTOM = 24;
     const BETWEEN_CARDS = 32;
     const CARD_RADIUS = 20;
-    const TOKEN_SIZE = 44;
     const TOKEN_GAP = 8;
     const CROWN_SIZE = 18;
+
+    const maxDancers = Math.max(leadsOrder.length, followsOrder.length);
+
+    // Fill available vertical space with rows
+    const availForRows = H - contentStartY
+        - 2 * (CARD_HEADER_H + CARD_PAD_BOTTOM)
+        - BETWEEN_CARDS;
+    const ROW_H = Math.max(72, Math.floor(availForRows / (2 * maxDancers)));
 
     const innerLeft = CARD_X + CARD_PAD_H;
     const innerRight = CARD_X + CARD_W - CARD_PAD_H;
 
-    // Row sub-layout: Rank | gap | Name | gap | Tokens (right portion)
-    const RANK_W = 36;
+    // Row sub-layout: Rank | gap | Name | gap | Tokens
+    const RANK_W = 40;
     const RANK_NAME_GAP = 16;
-    const NAME_W = 220;
+    const NAME_W = Math.round(ROW_H * 2.8);  // name column scales with row height
     const NAME_BADGE_GAP = 24;
     const badgeStartX = innerLeft + RANK_W + RANK_NAME_GAP + NAME_W + NAME_BADGE_GAP;
     const badgeAreaW = innerRight - badgeStartX;
 
-    // Token sizing: 44 px target, scale down only when necessary
+    // Token sizing: scale with row height, constrained by horizontal space
     const allRoundCounts = [
         ...[...leadsOrder].map(n => (resultsLeadMap.get(n) || []).length),
         ...[...followsOrder].map(n => (resultsFollowMap.get(n) || []).length),
     ];
     const maxRoundsPerDancer = Math.max(...allRoundCounts, 1);
     const tokenSizeFromW = Math.floor((badgeAreaW + TOKEN_GAP) / maxRoundsPerDancer) - TOKEN_GAP;
-    const tokenSize = Math.max(20, Math.min(TOKEN_SIZE, tokenSizeFromW));
+    const tokenSizeFromH = ROW_H - 22;
+    const tokenSize = Math.max(20, Math.min(tokenSizeFromH, tokenSizeFromW));
     const tokenFontSize = Math.max(10, Math.round(tokenSize * 0.46));
 
-    const NAME_SIZE = 34;
-    const RANK_SIZE = 28;
+    const NAME_SIZE = Math.min(48, Math.round(ROW_H * 0.46));
+    const RANK_SIZE = Math.min(40, Math.round(ROW_H * 0.38));
 
     // --- Draw one card section ---
     const drawSection = (order, map, topName, label, startY) => {
@@ -3394,14 +3401,11 @@ async function exportSocialImage() {
         ctx.fillStyle = C.ink;
         ctx.fillRect(CARD_X, startY, CARD_W, CARD_HEADER_H);
 
-        // Crown icon + section label in header
-        const HEADER_CROWN = 26;
-        const crownHCX = innerLeft + HEADER_CROWN * 0.7;
-        drawCrown(crownHCX, startY + CARD_HEADER_H / 2, HEADER_CROWN);
+        // Section label
         ctx.fillStyle = '#FFFFFF';
         ctx.font = `normal 56px "Anton","Bebas Neue","Space Grotesk",sans-serif`;
         ctx.textAlign = 'left';
-        ctx.fillText(label.toUpperCase(), innerLeft + HEADER_CROWN * 1.4 + 14, startY + CARD_HEADER_H - 14);
+        ctx.fillText(label.toUpperCase(), innerLeft, startY + CARD_HEADER_H - 14);
 
         // Contestant rows
         const rowsStartY = startY + CARD_HEADER_H;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3231,15 +3231,6 @@ async function exportSocialImage() {
     ctx.fillStyle = '#111111';
     ctx.fillRect(0, 0, W, 12);
 
-    const drawDivider = (y) => {
-        ctx.beginPath();
-        ctx.moveTo(PAD, y);
-        ctx.lineTo(W - PAD, y);
-        ctx.strokeStyle = 'rgba(0,0,0,0.12)';
-        ctx.lineWidth = 1.5;
-        ctx.stroke();
-    };
-
     // --- Header ---
     ctx.textAlign = 'center';
     ctx.fillStyle = '#000000';
@@ -3260,8 +3251,6 @@ async function exportSocialImage() {
         ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 258);
     }
 
-    drawDivider(288);
-
     const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));
     const sortedFollows = [...currentFollows].sort((a, b) => (b.points || 0) - (a.points || 0));
 
@@ -3272,11 +3261,14 @@ async function exportSocialImage() {
     const followsOrder = resultsInitialFollows.length ? resultsInitialFollows : sortedFollows.map(f => f.name);
     const numRounds = resultsNumRounds || 0;
 
-    // Layout: two stacked sections (Leads then Follows), each full width
-    const SECTION_LABEL_H = 44;
-    const SECTION_GAP = 24;
+    // Layout: two card sections (Leads then Follows)
+    const CARD_HEADER_H = 76;   // dark strip at top of each card
+    const CARD_PAD_BOTTOM = 16; // padding below last row inside card
+    const SECTION_GAP = 20;
     const FOOTER_H = 40;
-    const availForRows = (H - FOOTER_H) - contentStartY - 2 * SECTION_LABEL_H - SECTION_GAP;
+    const availForRows = (H - FOOTER_H) - contentStartY
+        - 2 * (CARD_HEADER_H + CARD_PAD_BOTTOM)
+        - SECTION_GAP;
     const maxDancers = Math.max(leadsOrder.length, followsOrder.length);
 
     // Badge sizing: fit all rounds on a single horizontal line per row
@@ -3304,12 +3296,37 @@ async function exportSocialImage() {
     const rankFontSize = Math.max(16, nameFontSize - 4);
 
     const drawSection = (order, map, topName, label, startY) => {
-        ctx.fillStyle = '#888888';
-        ctx.font = `500 ${rankFontSize + 6}px "Space Grotesk","DM Sans",sans-serif`;
-        ctx.textAlign = 'left';
-        ctx.fillText(label, PAD, startY + SECTION_LABEL_H - 10);
+        const CARD_RADIUS = 20;
+        const cardX = PAD - 12;
+        const cardW = W - 2 * (PAD - 12);
+        const cardH = CARD_HEADER_H + order.length * rowH + CARD_PAD_BOTTOM;
 
-        const rowsStartY = startY + SECTION_LABEL_H;
+        // Card background (light)
+        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.fillStyle = '#f4f4f4';
+        ctx.fill();
+
+        // Dark header strip — clipped to card shape so top corners are rounded
+        ctx.save();
+        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.clip();
+        ctx.fillStyle = '#111111';
+        ctx.fillRect(cardX, startY, cardW, CARD_HEADER_H);
+        ctx.restore();
+
+        // Card border
+        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.strokeStyle = 'rgba(0,0,0,0.1)';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+
+        // Section label — white bold uppercase in dark strip
+        ctx.fillStyle = '#ffffff';
+        ctx.font = `bold 52px "Space Grotesk","DM Sans",sans-serif`;
+        ctx.textAlign = 'left';
+        ctx.fillText(label.toUpperCase(), cardX + 24, startY + CARD_HEADER_H - 18);
+
+        const rowsStartY = startY + CARD_HEADER_H;
 
         order.forEach((name, idx) => {
             const rowY = rowsStartY + idx * rowH;
@@ -3373,7 +3390,7 @@ async function exportSocialImage() {
             });
         });
 
-        return rowsStartY + order.length * rowH;
+        return rowsStartY + order.length * rowH + CARD_PAD_BOTTOM;
     };
 
     const leadsEnd = drawSection(leadsOrder, resultsLeadMap, resultsTopLeadName, 'Leads', contentStartY);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3246,23 +3246,21 @@ async function exportSocialImage() {
     ctx.font = 'bold 78px "Space Grotesk","DM Sans",sans-serif';
     ctx.fillText("Hustle n' Tussle", W / 2, 130);
 
-    ctx.fillStyle = '#222222';
-    ctx.font = '500 46px "Space Grotesk","DM Sans",sans-serif';
-    ctx.fillText('Final Results', W / 2, 200);
-
-    const dateStr = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+    const now = new Date();
+    const monthStr = now.toLocaleDateString('en-US', { month: 'long' });
+    const yearStr = now.getFullYear();
     ctx.fillStyle = '#888888';
-    ctx.font = '400 34px "Inter","DM Sans",sans-serif';
-    ctx.fillText(dateStr, W / 2, 248);
+    ctx.font = '400 38px "Inter","DM Sans",sans-serif';
+    ctx.fillText(`${monthStr} Edition (${yearStr})`, W / 2, 200);
 
     if (resultsGuestJudges.length > 0) {
         const judgeLabel = resultsGuestJudges.length === 1 ? 'Judge' : 'Judges';
         ctx.fillStyle = '#222222';
         ctx.font = '600 40px "Space Grotesk","DM Sans",sans-serif';
-        ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 298);
+        ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 258);
     }
 
-    drawDivider(324);
+    drawDivider(288);
 
     // --- Winner cards ---
     const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));
@@ -3270,16 +3268,16 @@ async function exportSocialImage() {
     const topLead = sortedLeads[0] || null;
     const topFollow = sortedFollows[0] || null;
 
-    let contentStartY = 340;
+    let contentStartY = 300;
     if (topLead || topFollow) {
         ctx.fillStyle = '#888888';
         ctx.font = '500 26px "Inter","DM Sans",sans-serif';
         ctx.textAlign = 'center';
-        ctx.fillText('WINNERS', W / 2, 360);
+        ctx.fillText('WINNERS', W / 2, 322);
 
         const cardW = 440;
         const cardH = 174;
-        const cardY = 374;
+        const cardY = 336;
         const cardGap = 20;
         const leftCardX = W / 2 - cardW - cardGap / 2;
         const rightCardX = W / 2 + cardGap / 2;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2783,7 +2783,17 @@ async function displayResults(data) {
         resultsTopLeadName = topLeadName;
         resultsTopFollowName = topFollowName;
         resultsNumRounds = totalRounds;
-        resultsGuestJudges = [...guestJudges];
+        resultsGuestJudges = guestJudges.length > 0
+            ? [...guestJudges]
+            : (() => {
+                // Fallback: extract unique judge names from rounds data
+                // (handles page-reload case where guestJudges global was reset)
+                const seen = new Set();
+                (data.rounds || []).forEach(r => {
+                    if (Array.isArray(r.judges)) r.judges.forEach(j => seen.add(j));
+                });
+                return [...seen];
+            })();
     }
     
     console.log('Round history:', data.rounds);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3278,36 +3278,76 @@ async function exportSocialImage() {
 
     await document.fonts.ready;
 
+    // Mirror the app's current light/dark theme
+    const isDark = document.documentElement.getAttribute('data-color') === 'dark';
+    const C = isDark ? {
+        bg:            '#0a0a12',
+        bgCard:        '#1a1a2e',
+        accent:        '#7c3aed',
+        textPrimary:   '#f1f5f9',
+        textSecondary: '#94a3b8',
+        textMuted:     '#64748b',
+        border:        'rgba(148,163,184,0.12)',
+        rowAlt:        'rgba(255,255,255,0.03)',
+        badgeWin:      '#7c3aed',
+        badgeWinBorder:'#9d5cf5',
+        badgeLose:     'rgba(255,255,255,0.07)',
+        badgeLoseBorder:'rgba(148,163,184,0.15)',
+        badgeWinText:  '#ffffff',
+        badgeLoseText: '#64748b',
+        fontDisplay:   '"Space Grotesk","Inter",sans-serif',
+        fontBody:      '"Inter","DM Sans",sans-serif',
+        fontMono:      '"DM Mono",monospace',
+    } : {
+        bg:            '#f5f5f7',
+        bgCard:        '#ffffff',
+        accent:        '#1d4ed8',
+        textPrimary:   '#0f172a',
+        textSecondary: '#475569',
+        textMuted:     '#94a3b8',
+        border:        '#e2e8f0',
+        rowAlt:        'rgba(0,0,0,0.03)',
+        badgeWin:      '#1d4ed8',
+        badgeWinBorder:'#1e40af',
+        badgeLose:     '#f0f0f5',
+        badgeLoseBorder:'#e2e8f0',
+        badgeWinText:  '#ffffff',
+        badgeLoseText: '#94a3b8',
+        fontDisplay:   '"DM Sans",sans-serif',
+        fontBody:      '"DM Sans",sans-serif',
+        fontMono:      '"DM Mono",monospace',
+    };
+
     const canvas = document.createElement('canvas');
     canvas.width = W;
     canvas.height = H;
     const ctx = canvas.getContext('2d');
 
-    // Background — white
-    ctx.fillStyle = '#ffffff';
+    // Background
+    ctx.fillStyle = C.bg;
     ctx.fillRect(0, 0, W, H);
 
-    // Top accent bar — black
-    ctx.fillStyle = '#111111';
+    // Top accent bar
+    ctx.fillStyle = C.accent;
     ctx.fillRect(0, 0, W, 12);
 
     // --- Header ---
     ctx.textAlign = 'center';
-    ctx.fillStyle = '#000000';
-    ctx.font = 'bold 78px "Space Grotesk","DM Sans",sans-serif';
+    ctx.fillStyle = C.textPrimary;
+    ctx.font = `bold 78px ${C.fontDisplay}`;
     ctx.fillText("Hustle n' Tussle", W / 2, 130);
 
     const now = new Date();
     const monthStr = now.toLocaleDateString('en-US', { month: 'long' });
     const yearStr = now.getFullYear();
-    ctx.fillStyle = '#888888';
-    ctx.font = '400 38px "Inter","DM Sans",sans-serif';
+    ctx.fillStyle = C.textSecondary;
+    ctx.font = `400 38px ${C.fontBody}`;
     ctx.fillText(`${monthStr} Edition (${yearStr})`, W / 2, 200);
 
     if (resultsGuestJudges.length > 0) {
         const judgeLabel = resultsGuestJudges.length === 1 ? 'Judge' : 'Judges';
-        ctx.fillStyle = '#222222';
-        ctx.font = '600 40px "Space Grotesk","DM Sans",sans-serif';
+        ctx.fillStyle = C.textSecondary;
+        ctx.font = `600 40px ${C.fontDisplay}`;
         ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 258);
     }
 
@@ -3361,28 +3401,28 @@ async function exportSocialImage() {
         const cardW = W - 2 * (PAD - 12);
         const cardH = CARD_HEADER_H + order.length * rowH + CARD_PAD_BOTTOM;
 
-        // Card background (light)
+        // Card background
         _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
-        ctx.fillStyle = '#f4f4f4';
+        ctx.fillStyle = C.bgCard;
         ctx.fill();
 
-        // Dark header strip — clipped to card shape so top corners are rounded
+        // Accent header strip — clipped to card shape so top corners are rounded
         ctx.save();
         _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
         ctx.clip();
-        ctx.fillStyle = '#111111';
+        ctx.fillStyle = C.accent;
         ctx.fillRect(cardX, startY, cardW, CARD_HEADER_H);
         ctx.restore();
 
         // Card border
         _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
-        ctx.strokeStyle = 'rgba(0,0,0,0.1)';
+        ctx.strokeStyle = C.border;
         ctx.lineWidth = 1.5;
         ctx.stroke();
 
-        // Section label — white bold uppercase in dark strip
+        // Section label — white bold uppercase in header strip
         ctx.fillStyle = '#ffffff';
-        ctx.font = `bold 52px "Space Grotesk","DM Sans",sans-serif`;
+        ctx.font = `bold 52px ${C.fontDisplay}`;
         ctx.textAlign = 'left';
         ctx.fillText(label.toUpperCase(), cardX + 24, startY + CARD_HEADER_H - 18);
 
@@ -3395,13 +3435,13 @@ async function exportSocialImage() {
 
             // Alternating row tint
             if (idx % 2 === 0) {
-                ctx.fillStyle = 'rgba(0,0,0,0.04)';
+                ctx.fillStyle = C.rowAlt;
                 ctx.fillRect(PAD - 8, rowY + 1, W - (PAD - 8) * 2, rowH - 1);
             }
 
             // Rank
-            ctx.fillStyle = '#aaaaaa';
-            ctx.font = `400 ${rankFontSize}px "DM Mono",monospace`;
+            ctx.fillStyle = C.textMuted;
+            ctx.font = `400 ${rankFontSize}px ${C.fontMono}`;
             ctx.textAlign = 'left';
             ctx.fillText((idx + 1) + '.', PAD, textBaseY);
 
@@ -3412,10 +3452,10 @@ async function exportSocialImage() {
             ctx.clip();
             const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
             const displayName = name.length > maxChars ? name.slice(0, maxChars - 1) + '…' : name;
-            ctx.fillStyle = isTop ? '#111111' : '#555555';
+            ctx.fillStyle = isTop ? C.textPrimary : C.textSecondary;
             ctx.font = isTop
-                ? `bold ${nameFontSize}px "DM Sans",sans-serif`
-                : `400 ${nameFontSize}px "DM Sans",sans-serif`;
+                ? `bold ${nameFontSize}px ${C.fontBody}`
+                : `400 ${nameFontSize}px ${C.fontBody}`;
             ctx.fillText(displayName, PAD + rankW, textBaseY);
             if (isTop) {
                 const nameW2 = ctx.measureText(displayName).width;
@@ -3434,17 +3474,17 @@ async function exportSocialImage() {
 
                 ctx.beginPath();
                 ctx.arc(cx, cy, r, 0, Math.PI * 2);
-                ctx.fillStyle = info.win ? '#111111' : '#f0f0f0';
+                ctx.fillStyle = info.win ? C.badgeWin : C.badgeLose;
                 ctx.fill();
 
                 ctx.beginPath();
                 ctx.arc(cx, cy, r - 0.75, 0, Math.PI * 2);
-                ctx.strokeStyle = info.win ? '#333333' : 'rgba(0,0,0,0.2)';
+                ctx.strokeStyle = info.win ? C.badgeWinBorder : C.badgeLoseBorder;
                 ctx.lineWidth = 1.5;
                 ctx.stroke();
 
-                ctx.fillStyle = info.win ? '#ffffff' : '#aaaaaa';
-                ctx.font = `bold ${bFontSize}px "DM Mono",monospace`;
+                ctx.fillStyle = info.win ? C.badgeWinText : C.badgeLoseText;
+                ctx.font = `bold ${bFontSize}px ${C.fontMono}`;
                 ctx.textAlign = 'center';
                 ctx.fillText(String(info.round), cx, cy + bFontSize * 0.37);
             });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3262,58 +3262,10 @@ async function exportSocialImage() {
 
     drawDivider(288);
 
-    // --- Winner cards ---
     const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));
     const sortedFollows = [...currentFollows].sort((a, b) => (b.points || 0) - (a.points || 0));
-    const topLead = sortedLeads[0] || null;
-    const topFollow = sortedFollows[0] || null;
 
-    let contentStartY = 300;
-    if (topLead || topFollow) {
-        ctx.fillStyle = '#888888';
-        ctx.font = '500 26px "Inter","DM Sans",sans-serif';
-        ctx.textAlign = 'center';
-        ctx.fillText('WINNERS', W / 2, 322);
-
-        const cardW = 440;
-        const cardH = 174;
-        const cardY = 336;
-        const cardGap = 20;
-        const leftCardX = W / 2 - cardW - cardGap / 2;
-        const rightCardX = W / 2 + cardGap / 2;
-
-        const drawWinnerCard = (contestant, label, x) => {
-            if (!contestant) return;
-            ctx.fillStyle = 'rgba(0,0,0,0.04)';
-            _rrect(ctx, x, cardY, cardW, cardH, 16);
-            ctx.fill();
-            ctx.strokeStyle = 'rgba(0,0,0,0.2)';
-            ctx.lineWidth = 1.5;
-            _rrect(ctx, x, cardY, cardW, cardH, 16);
-            ctx.stroke();
-
-            ctx.fillStyle = '#555555';
-            ctx.font = '500 24px "Inter","DM Sans",sans-serif';
-            ctx.textAlign = 'center';
-            ctx.fillText(label, x + cardW / 2, cardY + 38);
-
-            ctx.fillStyle = '#111111';
-            ctx.font = 'bold 38px "Space Grotesk","DM Sans",sans-serif';
-            const name = contestant.name.length > 13 ? contestant.name.slice(0, 12) + '…' : contestant.name;
-            ctx.fillText('👑 ' + name, x + cardW / 2, cardY + 98);
-
-            ctx.fillStyle = '#666666';
-            ctx.font = '500 28px "DM Mono",monospace';
-            ctx.fillText(contestant.points + ' pts', x + cardW / 2, cardY + 144);
-        };
-
-        drawWinnerCard(topLead, 'Lead', leftCardX);
-        drawWinnerCard(topFollow, 'Follow', rightCardX);
-        contentStartY = cardY + cardH + 18;
-    }
-
-    drawDivider(contentStartY);
-    contentStartY += 12;
+    const contentStartY = 300;
 
     // --- Battle Graphic ---
     const leadsOrder = resultsInitialLeads.length ? resultsInitialLeads : sortedLeads.map(l => l.name);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3223,52 +3223,46 @@ async function exportSocialImage() {
     canvas.height = H;
     const ctx = canvas.getContext('2d');
 
-    // Background
-    const bgGrad = ctx.createLinearGradient(0, 0, 0, H);
-    bgGrad.addColorStop(0, '#0d0d1a');
-    bgGrad.addColorStop(1, '#0a0a12');
-    ctx.fillStyle = bgGrad;
+    // Background — white
+    ctx.fillStyle = '#ffffff';
     ctx.fillRect(0, 0, W, H);
 
-    // Top accent bar
-    const barGrad = ctx.createLinearGradient(0, 0, W, 0);
-    barGrad.addColorStop(0, '#7c3aed');
-    barGrad.addColorStop(1, '#6d28d9');
-    ctx.fillStyle = barGrad;
-    ctx.fillRect(0, 0, W, 10);
+    // Top accent bar — black
+    ctx.fillStyle = '#111111';
+    ctx.fillRect(0, 0, W, 12);
 
     const drawDivider = (y) => {
         ctx.beginPath();
         ctx.moveTo(PAD, y);
         ctx.lineTo(W - PAD, y);
-        ctx.strokeStyle = 'rgba(148,163,184,0.15)';
+        ctx.strokeStyle = 'rgba(0,0,0,0.12)';
         ctx.lineWidth = 1.5;
         ctx.stroke();
     };
 
     // --- Header ---
     ctx.textAlign = 'center';
-    ctx.fillStyle = '#f1f5f9';
+    ctx.fillStyle = '#000000';
     ctx.font = 'bold 78px "Space Grotesk","DM Sans",sans-serif';
     ctx.fillText("Hustle n' Tussle", W / 2, 130);
 
-    ctx.fillStyle = '#7c3aed';
+    ctx.fillStyle = '#222222';
     ctx.font = '500 46px "Space Grotesk","DM Sans",sans-serif';
     ctx.fillText('Final Results', W / 2, 200);
 
     const dateStr = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
-    ctx.fillStyle = '#475569';
+    ctx.fillStyle = '#888888';
     ctx.font = '400 34px "Inter","DM Sans",sans-serif';
     ctx.fillText(dateStr, W / 2, 248);
 
     if (resultsGuestJudges.length > 0) {
         const judgeLabel = resultsGuestJudges.length === 1 ? 'Judge' : 'Judges';
-        ctx.fillStyle = '#475569';
-        ctx.font = '400 26px "Inter","DM Sans",sans-serif';
-        ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 278);
+        ctx.fillStyle = '#222222';
+        ctx.font = '600 40px "Space Grotesk","DM Sans",sans-serif';
+        ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 298);
     }
 
-    drawDivider(298);
+    drawDivider(324);
 
     // --- Winner cards ---
     const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));
@@ -3276,41 +3270,41 @@ async function exportSocialImage() {
     const topLead = sortedLeads[0] || null;
     const topFollow = sortedFollows[0] || null;
 
-    let contentStartY = 310;
+    let contentStartY = 340;
     if (topLead || topFollow) {
-        ctx.fillStyle = '#64748b';
+        ctx.fillStyle = '#888888';
         ctx.font = '500 26px "Inter","DM Sans",sans-serif';
         ctx.textAlign = 'center';
-        ctx.fillText('WINNERS', W / 2, 334);
+        ctx.fillText('WINNERS', W / 2, 360);
 
         const cardW = 440;
         const cardH = 174;
-        const cardY = 348;
+        const cardY = 374;
         const cardGap = 20;
         const leftCardX = W / 2 - cardW - cardGap / 2;
         const rightCardX = W / 2 + cardGap / 2;
 
         const drawWinnerCard = (contestant, label, x) => {
             if (!contestant) return;
-            ctx.fillStyle = 'rgba(124,58,237,0.12)';
+            ctx.fillStyle = 'rgba(0,0,0,0.04)';
             _rrect(ctx, x, cardY, cardW, cardH, 16);
             ctx.fill();
-            ctx.strokeStyle = 'rgba(124,58,237,0.4)';
+            ctx.strokeStyle = 'rgba(0,0,0,0.2)';
             ctx.lineWidth = 1.5;
             _rrect(ctx, x, cardY, cardW, cardH, 16);
             ctx.stroke();
 
-            ctx.fillStyle = '#7c3aed';
+            ctx.fillStyle = '#555555';
             ctx.font = '500 24px "Inter","DM Sans",sans-serif';
             ctx.textAlign = 'center';
             ctx.fillText(label, x + cardW / 2, cardY + 38);
 
-            ctx.fillStyle = '#f1f5f9';
+            ctx.fillStyle = '#111111';
             ctx.font = 'bold 38px "Space Grotesk","DM Sans",sans-serif';
             const name = contestant.name.length > 13 ? contestant.name.slice(0, 12) + '…' : contestant.name;
             ctx.fillText('👑 ' + name, x + cardW / 2, cardY + 98);
 
-            ctx.fillStyle = '#94a3b8';
+            ctx.fillStyle = '#666666';
             ctx.font = '500 28px "DM Mono",monospace';
             ctx.fillText(contestant.points + ' pts', x + cardW / 2, cardY + 144);
         };
@@ -3331,7 +3325,7 @@ async function exportSocialImage() {
     // Layout: two stacked sections (Leads then Follows), each full width
     const SECTION_LABEL_H = 44;
     const SECTION_GAP = 24;
-    const FOOTER_H = 120;
+    const FOOTER_H = 40;
     const availForRows = (H - FOOTER_H) - contentStartY - 2 * SECTION_LABEL_H - SECTION_GAP;
     const maxDancers = Math.max(leadsOrder.length, followsOrder.length);
 
@@ -3353,7 +3347,7 @@ async function exportSocialImage() {
     const rankFontSize = Math.max(16, nameFontSize - 4);
 
     const drawSection = (order, map, topName, label, startY) => {
-        ctx.fillStyle = '#64748b';
+        ctx.fillStyle = '#888888';
         ctx.font = `500 ${rankFontSize + 6}px "Space Grotesk","DM Sans",sans-serif`;
         ctx.textAlign = 'left';
         ctx.fillText(label, PAD, startY + SECTION_LABEL_H - 10);
@@ -3367,12 +3361,12 @@ async function exportSocialImage() {
 
             // Alternating row tint
             if (idx % 2 === 0) {
-                ctx.fillStyle = 'rgba(255,255,255,0.025)';
+                ctx.fillStyle = 'rgba(0,0,0,0.04)';
                 ctx.fillRect(PAD - 8, rowY + 1, W - (PAD - 8) * 2, rowH - 1);
             }
 
             // Rank
-            ctx.fillStyle = '#475569';
+            ctx.fillStyle = '#aaaaaa';
             ctx.font = `400 ${rankFontSize}px "DM Mono",monospace`;
             ctx.textAlign = 'left';
             ctx.fillText((idx + 1) + '.', PAD, textBaseY);
@@ -3380,7 +3374,7 @@ async function exportSocialImage() {
             // Name (truncated to fit)
             const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
             const displayName = name.length > maxChars ? name.slice(0, maxChars - 1) + '…' : name;
-            ctx.fillStyle = isTop ? '#f1f5f9' : '#94a3b8';
+            ctx.fillStyle = isTop ? '#111111' : '#555555';
             ctx.font = isTop
                 ? `bold ${nameFontSize}px "DM Sans",sans-serif`
                 : `400 ${nameFontSize}px "DM Sans",sans-serif`;
@@ -3403,17 +3397,17 @@ async function exportSocialImage() {
 
                 ctx.beginPath();
                 ctx.arc(cx, cy, r, 0, Math.PI * 2);
-                ctx.fillStyle = info.win ? '#7c3aed' : 'rgba(25,25,46,0.9)';
+                ctx.fillStyle = info.win ? '#111111' : '#f0f0f0';
                 ctx.fill();
 
                 ctx.beginPath();
                 ctx.arc(cx, cy, r - 0.75, 0, Math.PI * 2);
-                ctx.strokeStyle = info.win ? 'rgba(167,139,250,0.8)' : 'rgba(100,116,139,0.35)';
+                ctx.strokeStyle = info.win ? '#333333' : 'rgba(0,0,0,0.2)';
                 ctx.lineWidth = 1.5;
                 ctx.stroke();
 
                 const bFontSize = Math.max(9, badgeSize - 13);
-                ctx.fillStyle = info.win ? '#fff' : '#475569';
+                ctx.fillStyle = info.win ? '#ffffff' : '#aaaaaa';
                 ctx.font = `bold ${bFontSize}px "DM Mono",monospace`;
                 ctx.textAlign = 'center';
                 ctx.fillText(String(info.round), cx, cy + bFontSize * 0.37);
@@ -3425,13 +3419,6 @@ async function exportSocialImage() {
 
     const leadsEnd = drawSection(leadsOrder, resultsLeadMap, resultsTopLeadName, 'Leads', contentStartY);
     drawSection(followsOrder, resultsFollowMap, resultsTopFollowName, 'Follows', leadsEnd + SECTION_GAP);
-
-    // --- Footer ---
-    drawDivider(H - 110);
-    ctx.fillStyle = '#334155';
-    ctx.font = '400 28px "Space Grotesk","DM Sans",sans-serif';
-    ctx.textAlign = 'center';
-    ctx.fillText("hustle n' tussle", W / 2, H - 56);
 
     canvas.toBlob(blob => {
         if (!blob) { showToast('Failed to generate image', 'error'); return; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -11,6 +11,15 @@ let initialLeads = []; // Store initial order of leads
 let initialFollows = []; // Store initial order of follows
 let contestantJudgingEnabled = true; // Track whether contestant judging is enabled for the battle
 
+// Cached data for the social export image (populated by displayResults)
+let resultsLeadMap = new Map();
+let resultsFollowMap = new Map();
+let resultsInitialLeads = [];
+let resultsInitialFollows = [];
+let resultsTopLeadName = null;
+let resultsTopFollowName = null;
+let resultsNumRounds = 0;
+
 // Display mode state (for viewer-only mode without voting controls)
 let displayMode = false;
 let displayPollInterval = null;
@@ -2764,6 +2773,15 @@ async function displayResults(data) {
 
         renderGraphicColumn(initialLeadsData || [], leadMap, topLeadName, leadGraphic);
         renderGraphicColumn(initialFollowsData || [], followMap, topFollowName, followGraphic);
+
+        // Cache for social export
+        resultsLeadMap = leadMap;
+        resultsFollowMap = followMap;
+        resultsInitialLeads = [...(initialLeadsData || [])];
+        resultsInitialFollows = [...(initialFollowsData || [])];
+        resultsTopLeadName = topLeadName;
+        resultsTopFollowName = topFollowName;
+        resultsNumRounds = totalRounds;
     }
     
     console.log('Round history:', data.rounds);
@@ -3184,6 +3202,7 @@ function _rrect(ctx, x, y, w, h, r) {
 async function exportSocialImage() {
     const W = 1080;
     const H = 1920;
+    const PAD = 80;
 
     await document.fonts.ready;
 
@@ -3208,49 +3227,46 @@ async function exportSocialImage() {
 
     const drawDivider = (y) => {
         ctx.beginPath();
-        ctx.moveTo(80, y);
-        ctx.lineTo(W - 80, y);
+        ctx.moveTo(PAD, y);
+        ctx.lineTo(W - PAD, y);
         ctx.strokeStyle = 'rgba(148,163,184,0.15)';
         ctx.lineWidth = 1.5;
         ctx.stroke();
     };
 
-    // Title
+    // --- Header ---
     ctx.textAlign = 'center';
     ctx.fillStyle = '#f1f5f9';
-    ctx.font = 'bold 78px "Space Grotesk", "DM Sans", sans-serif';
+    ctx.font = 'bold 78px "Space Grotesk","DM Sans",sans-serif';
     ctx.fillText("Hustle n' Tussle", W / 2, 130);
 
     ctx.fillStyle = '#7c3aed';
-    ctx.font = '500 46px "Space Grotesk", "DM Sans", sans-serif';
+    ctx.font = '500 46px "Space Grotesk","DM Sans",sans-serif';
     ctx.fillText('Final Results', W / 2, 200);
 
     const dateStr = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
     ctx.fillStyle = '#475569';
-    ctx.font = '400 34px "Inter", "DM Sans", sans-serif';
+    ctx.font = '400 34px "Inter","DM Sans",sans-serif';
     ctx.fillText(dateStr, W / 2, 258);
 
     drawDivider(294);
 
-    // Sort by points descending
+    // --- Winner cards ---
     const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));
     const sortedFollows = [...currentFollows].sort((a, b) => (b.points || 0) - (a.points || 0));
     const topLead = sortedLeads[0] || null;
     const topFollow = sortedFollows[0] || null;
 
-    // Winners section
-    let afterWinnersY = 310;
+    let contentStartY = 310;
     if (topLead || topFollow) {
         ctx.fillStyle = '#64748b';
-        ctx.font = '500 28px "Inter", "DM Sans", sans-serif';
+        ctx.font = '500 26px "Inter","DM Sans",sans-serif';
         ctx.textAlign = 'center';
-        ctx.letterSpacing = '2px';
-        ctx.fillText('WINNERS', W / 2, 340);
-        ctx.letterSpacing = '0px';
+        ctx.fillText('WINNERS', W / 2, 334);
 
         const cardW = 440;
-        const cardH = 220;
-        const cardY = 360;
+        const cardH = 174;
+        const cardY = 348;
         const cardGap = 20;
         const leftCardX = W / 2 - cardW - cardGap / 2;
         const rightCardX = W / 2 + cardGap / 2;
@@ -3260,92 +3276,141 @@ async function exportSocialImage() {
             ctx.fillStyle = 'rgba(124,58,237,0.12)';
             _rrect(ctx, x, cardY, cardW, cardH, 16);
             ctx.fill();
-            ctx.strokeStyle = 'rgba(124,58,237,0.45)';
+            ctx.strokeStyle = 'rgba(124,58,237,0.4)';
             ctx.lineWidth = 1.5;
             _rrect(ctx, x, cardY, cardW, cardH, 16);
             ctx.stroke();
 
             ctx.fillStyle = '#7c3aed';
-            ctx.font = '500 26px "Inter", "DM Sans", sans-serif';
+            ctx.font = '500 24px "Inter","DM Sans",sans-serif';
             ctx.textAlign = 'center';
-            ctx.fillText(label, x + cardW / 2, cardY + 46);
+            ctx.fillText(label, x + cardW / 2, cardY + 38);
 
             ctx.fillStyle = '#f1f5f9';
-            ctx.font = 'bold 40px "Space Grotesk", "DM Sans", sans-serif';
+            ctx.font = 'bold 38px "Space Grotesk","DM Sans",sans-serif';
             const name = contestant.name.length > 13 ? contestant.name.slice(0, 12) + '…' : contestant.name;
-            ctx.fillText('👑 ' + name, x + cardW / 2, cardY + 114);
+            ctx.fillText('👑 ' + name, x + cardW / 2, cardY + 98);
 
             ctx.fillStyle = '#94a3b8';
-            ctx.font = '500 30px "DM Mono", monospace';
-            ctx.fillText(contestant.points + ' pts', x + cardW / 2, cardY + 162);
+            ctx.font = '500 28px "DM Mono",monospace';
+            ctx.fillText(contestant.points + ' pts', x + cardW / 2, cardY + 144);
         };
 
         drawWinnerCard(topLead, 'Lead', leftCardX);
         drawWinnerCard(topFollow, 'Follow', rightCardX);
-        afterWinnersY = cardY + cardH + 24;
+        contentStartY = cardY + cardH + 18;
     }
 
-    drawDivider(afterWinnersY);
+    drawDivider(contentStartY);
+    contentStartY += 12;
 
-    // Leaderboard
-    const colStartY = afterWinnersY + 16;
-    const PAD = 80;
-    const COL_GAP = 40;
-    const colW = (W - PAD * 2 - COL_GAP) / 2;
-    const leftColX = PAD;
-    const rightColX = PAD + colW + COL_GAP;
+    // --- Battle Graphic ---
+    const leadsOrder = resultsInitialLeads.length ? resultsInitialLeads : sortedLeads.map(l => l.name);
+    const followsOrder = resultsInitialFollows.length ? resultsInitialFollows : sortedFollows.map(f => f.name);
+    const numRounds = resultsNumRounds || 0;
 
-    ctx.textAlign = 'left';
-    ctx.fillStyle = '#64748b';
-    ctx.font = '500 30px "Space Grotesk", "DM Sans", sans-serif';
-    ctx.fillText('Leads', leftColX, colStartY + 30);
-    ctx.fillText('Follows', rightColX, colStartY + 30);
+    // Layout: two stacked sections (Leads then Follows), each full width
+    const SECTION_LABEL_H = 44;
+    const SECTION_GAP = 24;
+    const FOOTER_H = 120;
+    const availForRows = (H - FOOTER_H) - contentStartY - 2 * SECTION_LABEL_H - SECTION_GAP;
+    const maxDancers = Math.max(leadsOrder.length, followsOrder.length);
 
-    const rowStartY = colStartY + 46;
-    const maxRows = Math.max(sortedLeads.length, sortedFollows.length);
-    const availH = H - rowStartY - 140;
-    const rowH = Math.max(52, Math.min(72, Math.floor(availH / Math.max(maxRows, 1))));
-    const nameFontSize = rowH >= 66 ? 34 : rowH >= 58 ? 30 : 26;
+    // Badge sizing: fit all rounds on a single horizontal line per row
+    const rankW = 44;
+    const nameAreaW = 228;
+    const badgeStartX = PAD + rankW + nameAreaW + 16;
+    const badgeAreaW = W - PAD - badgeStartX;
+    const badgeGap = 4;
+    const badgeSizeFromRounds = numRounds > 0
+        ? Math.floor((badgeAreaW + badgeGap) / numRounds) - badgeGap
+        : 40;
 
-    const drawRow = (contestant, x, i, isTop) => {
-        if (!contestant) return;
-        const y = rowStartY + i * rowH;
+    // rowH must satisfy both: fit all dancers and fit badge size
+    const maxRowHFromSpace = maxDancers > 0 ? Math.floor(availForRows / (2 * maxDancers)) : 70;
+    const badgeSize = Math.max(16, Math.min(40, Math.min(maxRowHFromSpace - 18, badgeSizeFromRounds)));
+    const rowH = Math.max(36, Math.min(maxRowHFromSpace, badgeSize + 18));
+    const nameFontSize = Math.max(20, Math.min(32, rowH - 10));
+    const rankFontSize = Math.max(16, nameFontSize - 4);
 
-        if (i % 2 === 0) {
-            ctx.fillStyle = 'rgba(255,255,255,0.025)';
-            ctx.fillRect(x - 8, y, colW + 8, rowH - 2);
-        }
-
-        ctx.fillStyle = '#475569';
-        ctx.font = `400 ${nameFontSize - 4}px "DM Mono", monospace`;
+    const drawSection = (order, map, topName, label, startY) => {
+        ctx.fillStyle = '#64748b';
+        ctx.font = `500 ${rankFontSize + 6}px "Space Grotesk","DM Sans",sans-serif`;
         ctx.textAlign = 'left';
-        ctx.fillText((i + 1) + '.', x, y + rowH * 0.65);
+        ctx.fillText(label, PAD, startY + SECTION_LABEL_H - 10);
 
-        const maxNameChars = Math.floor(colW / (nameFontSize * 0.58)) - 4;
-        const displayName = contestant.name.length > maxNameChars
-            ? contestant.name.slice(0, maxNameChars - 1) + '…'
-            : contestant.name;
-        ctx.fillStyle = isTop ? '#f1f5f9' : '#94a3b8';
-        ctx.font = isTop
-            ? `bold ${nameFontSize}px "DM Sans", sans-serif`
-            : `400 ${nameFontSize}px "DM Sans", sans-serif`;
-        ctx.fillText(displayName, x + 44, y + rowH * 0.65);
+        const rowsStartY = startY + SECTION_LABEL_H;
 
-        ctx.fillStyle = isTop ? '#7c3aed' : '#475569';
-        ctx.font = `bold ${nameFontSize}px "DM Mono", monospace`;
-        ctx.textAlign = 'right';
-        ctx.fillText(String(contestant.points), x + colW, y + rowH * 0.65);
+        order.forEach((name, idx) => {
+            const rowY = rowsStartY + idx * rowH;
+            const isTop = name === topName;
+            const textBaseY = rowY + rowH * 0.64;
+
+            // Alternating row tint
+            if (idx % 2 === 0) {
+                ctx.fillStyle = 'rgba(255,255,255,0.025)';
+                ctx.fillRect(PAD - 8, rowY + 1, W - (PAD - 8) * 2, rowH - 1);
+            }
+
+            // Rank
+            ctx.fillStyle = '#475569';
+            ctx.font = `400 ${rankFontSize}px "DM Mono",monospace`;
+            ctx.textAlign = 'left';
+            ctx.fillText((idx + 1) + '.', PAD, textBaseY);
+
+            // Name (truncated to fit)
+            const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
+            const displayName = name.length > maxChars ? name.slice(0, maxChars - 1) + '…' : name;
+            ctx.fillStyle = isTop ? '#f1f5f9' : '#94a3b8';
+            ctx.font = isTop
+                ? `bold ${nameFontSize}px "DM Sans",sans-serif`
+                : `400 ${nameFontSize}px "DM Sans",sans-serif`;
+            ctx.fillText(displayName, PAD + rankW, textBaseY);
+
+            // Crown after name for winner
+            if (isTop) {
+                const nameW2 = ctx.measureText(displayName).width;
+                ctx.font = `${nameFontSize}px serif`;
+                ctx.fillText('👑', PAD + rankW + nameW2 + 5, textBaseY);
+            }
+
+            // Round badges — one row of circles
+            const rounds = (map.get(name) || []).slice().sort((a, b) => a.round - b.round);
+            const badgeCY = rowY + rowH / 2;
+            rounds.forEach((info, bi) => {
+                const cx = badgeStartX + bi * (badgeSize + badgeGap) + badgeSize / 2;
+                const cy = badgeCY;
+                const r = badgeSize / 2;
+
+                ctx.beginPath();
+                ctx.arc(cx, cy, r, 0, Math.PI * 2);
+                ctx.fillStyle = info.win ? '#7c3aed' : 'rgba(25,25,46,0.9)';
+                ctx.fill();
+
+                ctx.beginPath();
+                ctx.arc(cx, cy, r - 0.75, 0, Math.PI * 2);
+                ctx.strokeStyle = info.win ? 'rgba(167,139,250,0.8)' : 'rgba(100,116,139,0.35)';
+                ctx.lineWidth = 1.5;
+                ctx.stroke();
+
+                const bFontSize = Math.max(9, badgeSize - 13);
+                ctx.fillStyle = info.win ? '#fff' : '#475569';
+                ctx.font = `bold ${bFontSize}px "DM Mono",monospace`;
+                ctx.textAlign = 'center';
+                ctx.fillText(String(info.round), cx, cy + bFontSize * 0.37);
+            });
+        });
+
+        return rowsStartY + order.length * rowH;
     };
 
-    for (let i = 0; i < maxRows; i++) {
-        drawRow(sortedLeads[i], leftColX, i, i === 0);
-        drawRow(sortedFollows[i], rightColX, i, i === 0);
-    }
+    const leadsEnd = drawSection(leadsOrder, resultsLeadMap, resultsTopLeadName, 'Leads', contentStartY);
+    drawSection(followsOrder, resultsFollowMap, resultsTopFollowName, 'Follows', leadsEnd + SECTION_GAP);
 
-    // Bottom branding
+    // --- Footer ---
     drawDivider(H - 110);
     ctx.fillStyle = '#334155';
-    ctx.font = '400 28px "Space Grotesk", "DM Sans", sans-serif';
+    ctx.font = '400 28px "Space Grotesk","DM Sans",sans-serif';
     ctx.textAlign = 'center';
     ctx.fillText("hustle n' tussle", W / 2, H - 56);
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3396,49 +3396,42 @@ async function exportSocialImage() {
     const leadsOrder = resultsInitialLeads.length ? resultsInitialLeads : sortedLeads.map(l => l.name);
     const followsOrder = resultsInitialFollows.length ? resultsInitialFollows : sortedFollows.map(f => f.name);
 
-    // --- Layout constants ---
+    // --- Layout constants (from design system) ---
     const CARD_X = 24;
     const CARD_W = W - 48;
-    const CARD_PAD_H = 24;
+    const CARD_PAD_H = 24;    // horizontal inner padding
     const CARD_HEADER_H = 72;
+    const ROW_H = 72;
     const CARD_PAD_BOTTOM = 24;
     const BETWEEN_CARDS = 32;
     const CARD_RADIUS = 20;
+    const TOKEN_SIZE = 44;
     const TOKEN_GAP = 8;
     const CROWN_SIZE = 18;
-
-    const maxDancers = Math.max(leadsOrder.length, followsOrder.length);
-
-    // Fill available vertical space with rows
-    const availForRows = H - contentStartY
-        - 2 * (CARD_HEADER_H + CARD_PAD_BOTTOM)
-        - BETWEEN_CARDS;
-    const ROW_H = Math.max(72, Math.floor(availForRows / (2 * maxDancers)));
 
     const innerLeft = CARD_X + CARD_PAD_H;
     const innerRight = CARD_X + CARD_W - CARD_PAD_H;
 
-    // Row sub-layout: Rank | gap | Name | gap | Tokens
-    const RANK_W = 40;
+    // Row sub-layout: Rank | gap | Name | gap | Tokens (right portion)
+    const RANK_W = 36;
     const RANK_NAME_GAP = 16;
-    const NAME_W = Math.round(ROW_H * 2.8);  // name column scales with row height
+    const NAME_W = 220;
     const NAME_BADGE_GAP = 24;
     const badgeStartX = innerLeft + RANK_W + RANK_NAME_GAP + NAME_W + NAME_BADGE_GAP;
     const badgeAreaW = innerRight - badgeStartX;
 
-    // Token sizing: scale with row height, constrained by horizontal space
+    // Token sizing: 44 px target, scale down only when necessary
     const allRoundCounts = [
         ...[...leadsOrder].map(n => (resultsLeadMap.get(n) || []).length),
         ...[...followsOrder].map(n => (resultsFollowMap.get(n) || []).length),
     ];
     const maxRoundsPerDancer = Math.max(...allRoundCounts, 1);
     const tokenSizeFromW = Math.floor((badgeAreaW + TOKEN_GAP) / maxRoundsPerDancer) - TOKEN_GAP;
-    const tokenSizeFromH = ROW_H - 22;
-    const tokenSize = Math.max(20, Math.min(tokenSizeFromH, tokenSizeFromW));
+    const tokenSize = Math.max(20, Math.min(TOKEN_SIZE, tokenSizeFromW));
     const tokenFontSize = Math.max(10, Math.round(tokenSize * 0.46));
 
-    const NAME_SIZE = Math.min(48, Math.round(ROW_H * 0.46));
-    const RANK_SIZE = Math.min(40, Math.round(ROW_H * 0.38));
+    const NAME_SIZE = 34;
+    const RANK_SIZE = 28;
 
     // --- Draw one card section ---
     const drawSection = (order, map, topName, label, startY) => {
@@ -3461,11 +3454,14 @@ async function exportSocialImage() {
         ctx.fillStyle = C.ink;
         ctx.fillRect(CARD_X, startY, CARD_W, CARD_HEADER_H);
 
-        // Section label
+        // Crown icon + section label in header
+        const HEADER_CROWN = 26;
+        const crownHCX = innerLeft + HEADER_CROWN * 0.7;
+        drawCrown(crownHCX, startY + CARD_HEADER_H / 2, HEADER_CROWN);
         ctx.fillStyle = '#FFFFFF';
         ctx.font = `normal 56px "Anton","Bebas Neue","Space Grotesk",sans-serif`;
         ctx.textAlign = 'left';
-        ctx.fillText(label.toUpperCase(), innerLeft, startY + CARD_HEADER_H - 14);
+        ctx.fillText(label.toUpperCase(), innerLeft + HEADER_CROWN * 1.4 + 14, startY + CARD_HEADER_H - 14);
 
         // Contestant rows
         const rowsStartY = startY + CARD_HEADER_H;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3272,250 +3272,189 @@ function _rrect(ctx, x, y, w, h, r) {
 }
 
 async function exportSocialImage() {
-    const W = 1080, H = 1920;
+    const W = 1080;
+    const H = 1920;
+    const PAD = 50;
+
     await document.fonts.ready;
 
     const canvas = document.createElement('canvas');
-    canvas.width = W; canvas.height = H;
+    canvas.width = W;
+    canvas.height = H;
     const ctx = canvas.getContext('2d');
 
-    // Design tokens
-    const C = {
-        ink:      '#111111',
-        paper:    '#F8F7F4',
-        paperAlt: '#EFEDE9',
-        gray:     '#808080',
-        border:   '#D4D4D4',
-        gold:     '#F5B400',
-    };
-
-    // Background (paper, never pure white)
-    ctx.fillStyle = C.paper;
+    // Background — white
+    ctx.fillStyle = '#ffffff';
     ctx.fillRect(0, 0, W, H);
 
-    // Top accent bar
-    ctx.fillStyle = C.ink;
+    // Top accent bar — black
+    ctx.fillStyle = '#111111';
     ctx.fillRect(0, 0, W, 12);
 
-    // Custom crown path — gold, drawn at center (cx, cy), given height `size`
-    const drawCrown = (cx, cy, size) => {
-        const w = size * 1.4;
-        ctx.fillStyle = C.gold;
-        ctx.beginPath();
-        ctx.moveTo(cx - w / 2,    cy + size * 0.42);
-        ctx.lineTo(cx - w / 2,    cy - size * 0.08);
-        ctx.lineTo(cx - w * 0.15, cy + size * 0.22);
-        ctx.lineTo(cx,            cy - size * 0.52);
-        ctx.lineTo(cx + w * 0.15, cy + size * 0.22);
-        ctx.lineTo(cx + w / 2,    cy - size * 0.08);
-        ctx.lineTo(cx + w / 2,    cy + size * 0.42);
-        ctx.closePath();
-        ctx.fill();
-        // Dots at the three tips
-        const dr = size * 0.11;
-        [[cx - w / 2, cy - size * 0.08], [cx, cy - size * 0.52], [cx + w / 2, cy - size * 0.08]].forEach(([dx, dy]) => {
-            ctx.beginPath();
-            ctx.arc(dx, dy - dr * 0.7, dr, 0, Math.PI * 2);
-            ctx.fill();
-        });
-    };
-
     // --- Header ---
-    const TITLE_SIZE = 88;
-    const titleY = 12 + 60 + Math.round(TITLE_SIZE * 0.78); // baseline ≈ 141
     ctx.textAlign = 'center';
-    ctx.fillStyle = C.ink;
-    ctx.font = `${TITLE_SIZE}px "Permanent Marker","Knewave",cursive`;
-    ctx.fillText("Hustle n' Tussle", W / 2, titleY);
+    ctx.fillStyle = '#000000';
+    ctx.font = 'bold 78px "Space Grotesk","DM Sans",sans-serif';
+    ctx.fillText("Hustle n' Tussle", W / 2, 130);
 
-    const EDITION_SIZE = 38;
-    const editionY = titleY + Math.round(TITLE_SIZE * 0.22) + 18 + EDITION_SIZE; // gap 18
     const now = new Date();
-    const editionText = `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
-    ctx.fillStyle = C.gray;
-    ctx.font = `500 ${EDITION_SIZE}px "Inter","DM Sans",sans-serif`;
-    ctx.fillText(editionText, W / 2, editionY);
+    const monthStr = now.toLocaleDateString('en-US', { month: 'long' });
+    const yearStr = now.getFullYear();
+    ctx.fillStyle = '#888888';
+    ctx.font = '400 38px "Inter","DM Sans",sans-serif';
+    ctx.fillText(`${monthStr} Edition (${yearStr})`, W / 2, 200);
 
-    // Gold brush underline below edition
-    const edW = ctx.measureText(editionText).width;
-    const ulY = editionY + 10;
-    ctx.strokeStyle = C.gold;
-    ctx.lineWidth = 4;
-    ctx.lineCap = 'round';
-    ctx.beginPath();
-    ctx.moveTo(W / 2 - edW / 2, ulY);
-    ctx.quadraticCurveTo(W / 2 - edW / 4, ulY + 6, W / 2, ulY + 3);
-    ctx.quadraticCurveTo(W / 2 + edW / 4, ulY, W / 2 + edW / 2, ulY + 5);
-    ctx.stroke();
-
-    // Judges line (8 px below underline)
-    let contentStartY = ulY + 8 + 32; // no judges: 32px gap to cards
     if (resultsGuestJudges.length > 0) {
-        const JUDGES_SIZE = 36;
-        const judgesY = ulY + 8 + JUDGES_SIZE;
-        ctx.fillStyle = C.gray;
-        ctx.font = `500 ${JUDGES_SIZE}px "Inter","DM Sans",sans-serif`;
-        ctx.fillText(
-            `${resultsGuestJudges.length === 1 ? 'Judge' : 'Judges'}: ${resultsGuestJudges.join(', ')}`,
-            W / 2, judgesY
-        );
-        contentStartY = judgesY + 32;
+        const judgeLabel = resultsGuestJudges.length === 1 ? 'Judge' : 'Judges';
+        ctx.fillStyle = '#222222';
+        ctx.font = '600 40px "Space Grotesk","DM Sans",sans-serif';
+        ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 258);
     }
 
-    // --- Data ---
     const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));
     const sortedFollows = [...currentFollows].sort((a, b) => (b.points || 0) - (a.points || 0));
+
+    const contentStartY = 300;
+
+    // --- Battle Graphic ---
     const leadsOrder = resultsInitialLeads.length ? resultsInitialLeads : sortedLeads.map(l => l.name);
     const followsOrder = resultsInitialFollows.length ? resultsInitialFollows : sortedFollows.map(f => f.name);
+    const numRounds = resultsNumRounds || 0;
 
-    // --- Layout constants (from design system) ---
-    const CARD_X = 24;
-    const CARD_W = W - 48;
-    const CARD_PAD_H = 24;    // horizontal inner padding
-    const CARD_HEADER_H = 72;
-    const ROW_H = 72;
-    const CARD_PAD_BOTTOM = 24;
-    const BETWEEN_CARDS = 32;
-    const CARD_RADIUS = 20;
-    const TOKEN_SIZE = 44;
-    const TOKEN_GAP = 8;
-    const CROWN_SIZE = 18;
+    // Layout: two card sections (Leads then Follows)
+    const CARD_HEADER_H = 76;   // dark strip at top of each card
+    const CARD_PAD_BOTTOM = 16; // padding below last row inside card
+    const SECTION_GAP = 20;
+    const FOOTER_H = 40;
+    const availForRows = (H - FOOTER_H) - contentStartY
+        - 2 * (CARD_HEADER_H + CARD_PAD_BOTTOM)
+        - SECTION_GAP;
+    const maxDancers = Math.max(leadsOrder.length, followsOrder.length);
 
-    const innerLeft = CARD_X + CARD_PAD_H;
-    const innerRight = CARD_X + CARD_W - CARD_PAD_H;
+    // Badge sizing: fit all rounds on a single horizontal line per row
+    const rankW = 44;
+    const nameAreaW = 260;
+    const badgeStartX = PAD + rankW + nameAreaW + 24;
+    const badgeAreaW = W - PAD - badgeStartX;
+    const badgeGap = 4;
 
-    // Row sub-layout: Rank | gap | Name | gap | Tokens (right portion)
-    const RANK_W = 36;
-    const RANK_NAME_GAP = 16;
-    const NAME_W = 220;
-    const NAME_BADGE_GAP = 24;
-    const badgeStartX = innerLeft + RANK_W + RANK_NAME_GAP + NAME_W + NAME_BADGE_GAP;
-    const badgeAreaW = innerRight - badgeStartX;
-
-    // Token sizing: 44 px target, scale down only when necessary
+    // Use the most rounds any individual dancer competed in (not total game rounds)
+    // so the badge row fills the full width for the most active dancer.
     const allRoundCounts = [
         ...[...leadsOrder].map(n => (resultsLeadMap.get(n) || []).length),
         ...[...followsOrder].map(n => (resultsFollowMap.get(n) || []).length),
     ];
     const maxRoundsPerDancer = Math.max(...allRoundCounts, 1);
-    const tokenSizeFromW = Math.floor((badgeAreaW + TOKEN_GAP) / maxRoundsPerDancer) - TOKEN_GAP;
-    const tokenSize = Math.max(20, Math.min(TOKEN_SIZE, tokenSizeFromW));
-    const tokenFontSize = Math.max(10, Math.round(tokenSize * 0.46));
+    const badgeSizeFromRounds = Math.floor((badgeAreaW + badgeGap) / maxRoundsPerDancer) - badgeGap;
 
-    const NAME_SIZE = 34;
-    const RANK_SIZE = 28;
+    // rowH fills all available vertical space; badgeSize is the smaller of the two constraints
+    const maxRowHFromSpace = maxDancers > 0 ? Math.floor(availForRows / (2 * maxDancers)) : 70;
+    const rowH = Math.max(36, maxRowHFromSpace);
+    const badgeSize = Math.max(16, Math.min(rowH - 18, badgeSizeFromRounds));
+    const bFontSize = Math.max(9, Math.round(badgeSize * 0.52));
+    const nameFontSize = Math.max(20, Math.min(44, rowH - 26));
+    const rankFontSize = Math.max(16, nameFontSize - 4);
 
-    // --- Draw one card section ---
     const drawSection = (order, map, topName, label, startY) => {
-        const cardH = CARD_HEADER_H + order.length * ROW_H + CARD_PAD_BOTTOM;
+        const CARD_RADIUS = 20;
+        const cardX = PAD - 12;
+        const cardW = W - 2 * (PAD - 12);
+        const cardH = CARD_HEADER_H + order.length * rowH + CARD_PAD_BOTTOM;
 
-        // Card base (paper background + border)
-        _rrect(ctx, CARD_X, startY, CARD_W, cardH, CARD_RADIUS);
-        ctx.fillStyle = C.paper;
+        // Card background (light)
+        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.fillStyle = '#f4f4f4';
         ctx.fill();
-        ctx.strokeStyle = C.border;
-        ctx.lineWidth = 1;
+
+        // Dark header strip — clipped to card shape so top corners are rounded
+        ctx.save();
+        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.clip();
+        ctx.fillStyle = '#111111';
+        ctx.fillRect(cardX, startY, cardW, CARD_HEADER_H);
+        ctx.restore();
+
+        // Card border
+        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.strokeStyle = 'rgba(0,0,0,0.1)';
+        ctx.lineWidth = 1.5;
         ctx.stroke();
 
-        // Everything inside the card is clipped to its rounded shape
-        ctx.save();
-        _rrect(ctx, CARD_X, startY, CARD_W, cardH, CARD_RADIUS);
-        ctx.clip();
-
-        // Dark header strip
-        ctx.fillStyle = C.ink;
-        ctx.fillRect(CARD_X, startY, CARD_W, CARD_HEADER_H);
-
-        // Section label — Anton, white, ALL CAPS
-        ctx.fillStyle = '#FFFFFF';
-        ctx.font = `normal 56px "Anton","Bebas Neue","Space Grotesk",sans-serif`;
+        // Section label — white bold uppercase in dark strip
+        ctx.fillStyle = '#ffffff';
+        ctx.font = `bold 52px "Space Grotesk","DM Sans",sans-serif`;
         ctx.textAlign = 'left';
-        ctx.fillText(label.toUpperCase(), innerLeft, startY + CARD_HEADER_H - 14);
+        ctx.fillText(label.toUpperCase(), cardX + 24, startY + CARD_HEADER_H - 18);
 
-        // Contestant rows
         const rowsStartY = startY + CARD_HEADER_H;
+
         order.forEach((name, idx) => {
-            const rowY = rowsStartY + idx * ROW_H;
+            const rowY = rowsStartY + idx * rowH;
             const isTop = name === topName;
-            const baseY = rowY + Math.round(ROW_H * 0.625);
+            const textBaseY = rowY + rowH * 0.64;
 
-            // Alternating row background (Paper / PaperAlt)
-            ctx.fillStyle = idx % 2 === 0 ? C.paper : C.paperAlt;
-            ctx.fillRect(CARD_X, rowY, CARD_W, ROW_H);
-
-            // Row separator (almost invisible)
-            if (idx > 0) {
-                ctx.strokeStyle = 'rgba(0,0,0,0.06)';
-                ctx.lineWidth = 1;
-                ctx.beginPath();
-                ctx.moveTo(innerLeft, rowY);
-                ctx.lineTo(innerRight, rowY);
-                ctx.stroke();
+            // Alternating row tint
+            if (idx % 2 === 0) {
+                ctx.fillStyle = 'rgba(0,0,0,0.04)';
+                ctx.fillRect(PAD - 8, rowY + 1, W - (PAD - 8) * 2, rowH - 1);
             }
 
-            // Rank number
-            ctx.fillStyle = C.gray;
-            ctx.font = `400 ${RANK_SIZE}px "Inter","DM Sans",sans-serif`;
+            // Rank
+            ctx.fillStyle = '#aaaaaa';
+            ctx.font = `400 ${rankFontSize}px "DM Mono",monospace`;
             ctx.textAlign = 'left';
-            ctx.fillText(`${idx + 1}.`, innerLeft, baseY);
+            ctx.fillText((idx + 1) + '.', PAD, textBaseY);
 
-            // Name (clipped to name column so it never bleeds into tokens)
-            const nameX = innerLeft + RANK_W + RANK_NAME_GAP;
+            // Name + crown — clipped to nameAreaW so crown never bleeds into badge area
             ctx.save();
             ctx.beginPath();
-            ctx.rect(nameX, rowY, NAME_W, ROW_H);
+            ctx.rect(PAD + rankW, rowY, nameAreaW, rowH);
             ctx.clip();
-            ctx.fillStyle = isTop ? C.ink : '#444444';
-            ctx.font = `${isTop ? 700 : 600} ${NAME_SIZE}px "Inter","DM Sans",sans-serif`;
-            ctx.textAlign = 'left';
-            ctx.fillText(name, nameX, baseY);
+            const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
+            const displayName = name.length > maxChars ? name.slice(0, maxChars - 1) + '…' : name;
+            ctx.fillStyle = isTop ? '#111111' : '#555555';
+            ctx.font = isTop
+                ? `bold ${nameFontSize}px "DM Sans",sans-serif`
+                : `400 ${nameFontSize}px "DM Sans",sans-serif`;
+            ctx.fillText(displayName, PAD + rankW, textBaseY);
+            if (isTop) {
+                const nameW2 = ctx.measureText(displayName).width;
+                ctx.font = `${nameFontSize}px serif`;
+                ctx.fillText('👑', PAD + rankW + nameW2 + 5, textBaseY);
+            }
             ctx.restore();
 
-            // Crown icon (custom path, gold) placed after name if champion
-            if (isTop) {
-                ctx.font = `700 ${NAME_SIZE}px "Inter","DM Sans",sans-serif`;
-                const nameTextW = ctx.measureText(name).width;
-                const crownCX = nameX + nameTextW + 12 + CROWN_SIZE * 0.7;
-                if (crownCX + CROWN_SIZE < badgeStartX) {
-                    drawCrown(crownCX, baseY - NAME_SIZE * 0.38, CROWN_SIZE);
-                }
-            }
-
-            // Round tokens
+            // Round badges — one row of circles
             const rounds = (map.get(name) || []).slice().sort((a, b) => a.round - b.round);
-            const tokenCY = rowY + ROW_H / 2;
+            const badgeCY = rowY + rowH / 2;
             rounds.forEach((info, bi) => {
-                const cx = badgeStartX + bi * (tokenSize + TOKEN_GAP) + tokenSize / 2;
-                const r = tokenSize / 2;
+                const cx = badgeStartX + bi * (badgeSize + badgeGap) + badgeSize / 2;
+                const cy = badgeCY;
+                const r = badgeSize / 2;
 
-                // Token fill
                 ctx.beginPath();
-                ctx.arc(cx, tokenCY, r, 0, Math.PI * 2);
-                ctx.fillStyle = info.win ? C.ink : C.paper;
+                ctx.arc(cx, cy, r, 0, Math.PI * 2);
+                ctx.fillStyle = info.win ? '#111111' : '#f0f0f0';
                 ctx.fill();
 
-                // Token border
                 ctx.beginPath();
-                ctx.arc(cx, tokenCY, r - 1, 0, Math.PI * 2);
-                ctx.strokeStyle = info.win ? C.ink : C.border;
+                ctx.arc(cx, cy, r - 0.75, 0, Math.PI * 2);
+                ctx.strokeStyle = info.win ? '#333333' : 'rgba(0,0,0,0.2)';
                 ctx.lineWidth = 1.5;
                 ctx.stroke();
 
-                // Round number
-                ctx.fillStyle = info.win ? '#FFFFFF' : C.gray;
-                ctx.font = `700 ${tokenFontSize}px "Inter","DM Mono",monospace`;
+                ctx.fillStyle = info.win ? '#ffffff' : '#aaaaaa';
+                ctx.font = `bold ${bFontSize}px "DM Mono",monospace`;
                 ctx.textAlign = 'center';
-                ctx.fillText(String(info.round), cx, tokenCY + tokenFontSize * 0.37);
+                ctx.fillText(String(info.round), cx, cy + bFontSize * 0.37);
             });
         });
 
-        ctx.restore(); // end card clip
-
-        return rowsStartY + order.length * ROW_H + CARD_PAD_BOTTOM;
+        return rowsStartY + order.length * rowH + CARD_PAD_BOTTOM;
     };
 
     const leadsEnd = drawSection(leadsOrder, resultsLeadMap, resultsTopLeadName, 'Leads', contentStartY);
-    drawSection(followsOrder, resultsFollowMap, resultsTopFollowName, 'Follows', leadsEnd + BETWEEN_CARDS);
+    drawSection(followsOrder, resultsFollowMap, resultsTopFollowName, 'Follows', leadsEnd + SECTION_GAP);
 
     canvas.toBlob(blob => {
         if (!blob) { showToast('Failed to generate image', 'error'); return; }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3261,38 +3261,66 @@ async function exportSocialImage() {
     };
 
     // --- Header ---
-    const TITLE_SIZE = 88;
-    const titleY = 12 + 60 + Math.round(TITLE_SIZE * 0.78); // baseline ≈ 141
+    const now = new Date();
+    const TITLE_SIZE = 96;
+    const titleY = 12 + 52 + Math.round(TITLE_SIZE * 0.78); // baseline ≈ 151
     ctx.textAlign = 'center';
     ctx.fillStyle = C.ink;
     ctx.font = `${TITLE_SIZE}px "Permanent Marker","Knewave",cursive`;
     ctx.fillText("Hustle n' Tussle", W / 2, titleY);
 
-    const EDITION_SIZE = 38;
-    const editionY = titleY + Math.round(TITLE_SIZE * 0.22) + 18 + EDITION_SIZE; // gap 18
-    const now = new Date();
-    const editionText = `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
-    ctx.fillStyle = C.gray;
-    ctx.font = `500 ${EDITION_SIZE}px "Inter","DM Sans",sans-serif`;
-    ctx.fillText(editionText, W / 2, editionY);
-
-    // Gold brush underline below edition
-    const edW = ctx.measureText(editionText).width;
-    const ulY = editionY + 10;
+    // Gold rule directly below title
+    const ruleY = titleY + 14;
     ctx.strokeStyle = C.gold;
-    ctx.lineWidth = 4;
+    ctx.lineWidth = 5;
     ctx.lineCap = 'round';
     ctx.beginPath();
-    ctx.moveTo(W / 2 - edW / 2, ulY);
-    ctx.quadraticCurveTo(W / 2 - edW / 4, ulY + 6, W / 2, ulY + 3);
-    ctx.quadraticCurveTo(W / 2 + edW / 4, ulY, W / 2 + edW / 2, ulY + 5);
+    ctx.moveTo(W / 2 - 320, ruleY);
+    ctx.quadraticCurveTo(W / 2, ruleY + 5, W / 2 + 320, ruleY + 1);
     ctx.stroke();
 
-    // Judges line (8 px below underline)
-    let contentStartY = ulY + 8 + 32; // no judges: 32px gap to cards
+    // Date sticky-note tag — top right, slightly rotated
+    ctx.save();
+    ctx.translate(W - 72, titleY - 40);
+    ctx.rotate(0.09);
+    const tagW = 148, tagH = 96;
+    _rrect(ctx, -tagW / 2, -tagH / 2, tagW, tagH, 8);
+    ctx.fillStyle = C.gold;
+    ctx.fill();
+    ctx.fillStyle = C.ink;
+    ctx.font = `32px "Permanent Marker",cursive`;
+    ctx.textAlign = 'center';
+    ctx.fillText(`${now.toLocaleDateString('en-US', { month: 'short' })} ${now.getDate()},`, 0, -10);
+    ctx.fillText(`${now.getFullYear()}.`, 0, 30);
+    ctx.restore();
+
+    // Black brush-band for edition
+    const EDITION_SIZE = 42;
+    const bandGap = 18; // gap from rule to band
+    const bandH = EDITION_SIZE + 28;
+    const bandY = ruleY + bandGap;
+    const bandMid = bandY + bandH / 2;
+    // Rough brush-stroke shape
+    ctx.fillStyle = C.ink;
+    ctx.beginPath();
+    ctx.moveTo(24, bandY + 3);
+    ctx.quadraticCurveTo(W / 2, bandY - 5, W - 24, bandY + 6);
+    ctx.quadraticCurveTo(W - 18, bandMid, W - 24, bandY + bandH - 4);
+    ctx.quadraticCurveTo(W / 2, bandY + bandH + 6, 24, bandY + bandH - 2);
+    ctx.quadraticCurveTo(18, bandMid, 24, bandY + 3);
+    ctx.fill();
+    // Edition text in gold on the band
+    const editionText = `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
+    ctx.fillStyle = C.gold;
+    ctx.font = `${EDITION_SIZE}px "Permanent Marker",cursive`;
+    ctx.textAlign = 'center';
+    ctx.fillText(editionText, W / 2, bandY + bandH * 0.68);
+
+    // Judges line below the band
+    let contentStartY = bandY + bandH + 16 + 32; // no judges
     if (resultsGuestJudges.length > 0) {
-        const JUDGES_SIZE = 36;
-        const judgesY = ulY + 8 + JUDGES_SIZE;
+        const JUDGES_SIZE = 34;
+        const judgesY = bandY + bandH + 16 + JUDGES_SIZE;
         ctx.fillStyle = C.gray;
         ctx.font = `500 ${JUDGES_SIZE}px "Inter","DM Sans",sans-serif`;
         ctx.fillText(
@@ -3366,11 +3394,14 @@ async function exportSocialImage() {
         ctx.fillStyle = C.ink;
         ctx.fillRect(CARD_X, startY, CARD_W, CARD_HEADER_H);
 
-        // Section label — Anton, white, ALL CAPS
+        // Crown icon + section label in header
+        const HEADER_CROWN = 26;
+        const crownHCX = innerLeft + HEADER_CROWN * 0.7;
+        drawCrown(crownHCX, startY + CARD_HEADER_H / 2, HEADER_CROWN);
         ctx.fillStyle = '#FFFFFF';
         ctx.font = `normal 56px "Anton","Bebas Neue","Space Grotesk",sans-serif`;
         ctx.textAlign = 'left';
-        ctx.fillText(label.toUpperCase(), innerLeft, startY + CARD_HEADER_H - 14);
+        ctx.fillText(label.toUpperCase(), innerLeft + HEADER_CROWN * 1.4 + 14, startY + CARD_HEADER_H - 14);
 
         // Contestant rows
         const rowsStartY = startY + CARD_HEADER_H;
@@ -3442,7 +3473,7 @@ async function exportSocialImage() {
                 ctx.stroke();
 
                 // Round number
-                ctx.fillStyle = info.win ? '#FFFFFF' : C.gray;
+                ctx.fillStyle = info.win ? '#FFFFFF' : C.ink;
                 ctx.font = `700 ${tokenFontSize}px "Inter","DM Mono",monospace`;
                 ctx.textAlign = 'center';
                 ctx.fillText(String(info.round), cx, tokenCY + tokenFontSize * 0.37);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3214,7 +3214,7 @@ function _rrect(ctx, x, y, w, h, r) {
 async function exportSocialImage() {
     const W = 1080;
     const H = 1920;
-    const PAD = 80;
+    const PAD = 50;
 
     await document.fonts.ready;
 
@@ -3331,17 +3331,17 @@ async function exportSocialImage() {
 
     // Badge sizing: fit all rounds on a single horizontal line per row
     const rankW = 44;
-    const nameAreaW = 228;
-    const badgeStartX = PAD + rankW + nameAreaW + 16;
+    const nameAreaW = 260;
+    const badgeStartX = PAD + rankW + nameAreaW + 12;
     const badgeAreaW = W - PAD - badgeStartX;
     const badgeGap = 4;
     const badgeSizeFromRounds = numRounds > 0
         ? Math.floor((badgeAreaW + badgeGap) / numRounds) - badgeGap
-        : 40;
+        : 48;
 
     // rowH must satisfy both: fit all dancers and fit badge size
     const maxRowHFromSpace = maxDancers > 0 ? Math.floor(availForRows / (2 * maxDancers)) : 70;
-    const badgeSize = Math.max(16, Math.min(40, Math.min(maxRowHFromSpace - 18, badgeSizeFromRounds)));
+    const badgeSize = Math.max(16, Math.min(maxRowHFromSpace - 18, badgeSizeFromRounds));
     const rowH = Math.max(36, Math.min(maxRowHFromSpace, badgeSize + 18));
     const nameFontSize = Math.max(20, Math.min(32, rowH - 10));
     const rankFontSize = Math.max(16, nameFontSize - 4);

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -19,6 +19,7 @@ let resultsInitialFollows = [];
 let resultsTopLeadName = null;
 let resultsTopFollowName = null;
 let resultsNumRounds = 0;
+let resultsGuestJudges = [];
 
 // Display mode state (for viewer-only mode without voting controls)
 let displayMode = false;
@@ -2782,6 +2783,7 @@ async function displayResults(data) {
         resultsTopLeadName = topLeadName;
         resultsTopFollowName = topFollowName;
         resultsNumRounds = totalRounds;
+        resultsGuestJudges = [...guestJudges];
     }
     
     console.log('Round history:', data.rounds);
@@ -3247,9 +3249,16 @@ async function exportSocialImage() {
     const dateStr = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
     ctx.fillStyle = '#475569';
     ctx.font = '400 34px "Inter","DM Sans",sans-serif';
-    ctx.fillText(dateStr, W / 2, 258);
+    ctx.fillText(dateStr, W / 2, 248);
 
-    drawDivider(294);
+    if (resultsGuestJudges.length > 0) {
+        const judgeLabel = resultsGuestJudges.length === 1 ? 'Judge' : 'Judges';
+        ctx.fillStyle = '#475569';
+        ctx.font = '400 26px "Inter","DM Sans",sans-serif';
+        ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 278);
+    }
+
+    drawDivider(298);
 
     // --- Winner cards ---
     const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -142,7 +142,7 @@ let submitVotesBtn, votingResults;
 let leadWinnerPreview, followWinnerPreview, leadPreviewName, followPreviewName;
 let roundResultsSection, winMessages, nextRoundBtn, endBattleBtn;
 let leadsLeaderboard, followsLeaderboard;
-let backToHomeFromResultsBtn, downloadBattleDataBtn;
+let backToHomeFromResultsBtn, downloadBattleDataBtn, exportSocialImageBtn;
 // Vote confirmation modal elements
 let voteConfirmModal, voteConfirmCloseBtn, voteConfirmCancelBtn, voteConfirmSubmitBtn;
 let voteConfirmRound, voteConfirmLead1, voteConfirmLead2, voteConfirmFollow1, voteConfirmFollow2;
@@ -325,6 +325,7 @@ document.addEventListener('DOMContentLoaded', () => {
     followsLeaderboard = document.getElementById('follows-leaderboard');
     backToHomeFromResultsBtn = document.getElementById('back-to-home-from-results');
     downloadBattleDataBtn = document.getElementById('download-battle-data');
+    exportSocialImageBtn = document.getElementById('export-social-image');
     
     // Check if elements exist
     console.log('Checking elements:');
@@ -449,6 +450,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     downloadBattleDataBtn.addEventListener('click', downloadBattleData);
+    if (exportSocialImageBtn) exportSocialImageBtn.addEventListener('click', exportSocialImage);
 
     // Theme toggles (nav bar + floating for display mode)
     document.querySelectorAll('#theme-toggle, #theme-toggle-floating').forEach(btn => {
@@ -3159,6 +3161,201 @@ function renderPlaylistEmbed(track) {
     iframe.allow = 'encrypted-media';
     iframe.className = 'spotify-embed';
     playlistEmbedContainer.appendChild(iframe);
+}
+
+function _rrect(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+    ctx.lineTo(x + r, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+}
+
+async function exportSocialImage() {
+    const W = 1080;
+    const H = 1920;
+
+    await document.fonts.ready;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = W;
+    canvas.height = H;
+    const ctx = canvas.getContext('2d');
+
+    // Background
+    const bgGrad = ctx.createLinearGradient(0, 0, 0, H);
+    bgGrad.addColorStop(0, '#0d0d1a');
+    bgGrad.addColorStop(1, '#0a0a12');
+    ctx.fillStyle = bgGrad;
+    ctx.fillRect(0, 0, W, H);
+
+    // Top accent bar
+    const barGrad = ctx.createLinearGradient(0, 0, W, 0);
+    barGrad.addColorStop(0, '#7c3aed');
+    barGrad.addColorStop(1, '#6d28d9');
+    ctx.fillStyle = barGrad;
+    ctx.fillRect(0, 0, W, 10);
+
+    const drawDivider = (y) => {
+        ctx.beginPath();
+        ctx.moveTo(80, y);
+        ctx.lineTo(W - 80, y);
+        ctx.strokeStyle = 'rgba(148,163,184,0.15)';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+    };
+
+    // Title
+    ctx.textAlign = 'center';
+    ctx.fillStyle = '#f1f5f9';
+    ctx.font = 'bold 78px "Space Grotesk", "DM Sans", sans-serif';
+    ctx.fillText("Hustle n' Tussle", W / 2, 130);
+
+    ctx.fillStyle = '#7c3aed';
+    ctx.font = '500 46px "Space Grotesk", "DM Sans", sans-serif';
+    ctx.fillText('Final Results', W / 2, 200);
+
+    const dateStr = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+    ctx.fillStyle = '#475569';
+    ctx.font = '400 34px "Inter", "DM Sans", sans-serif';
+    ctx.fillText(dateStr, W / 2, 258);
+
+    drawDivider(294);
+
+    // Sort by points descending
+    const sortedLeads = [...currentLeads].sort((a, b) => (b.points || 0) - (a.points || 0));
+    const sortedFollows = [...currentFollows].sort((a, b) => (b.points || 0) - (a.points || 0));
+    const topLead = sortedLeads[0] || null;
+    const topFollow = sortedFollows[0] || null;
+
+    // Winners section
+    let afterWinnersY = 310;
+    if (topLead || topFollow) {
+        ctx.fillStyle = '#64748b';
+        ctx.font = '500 28px "Inter", "DM Sans", sans-serif';
+        ctx.textAlign = 'center';
+        ctx.letterSpacing = '2px';
+        ctx.fillText('WINNERS', W / 2, 340);
+        ctx.letterSpacing = '0px';
+
+        const cardW = 440;
+        const cardH = 220;
+        const cardY = 360;
+        const cardGap = 20;
+        const leftCardX = W / 2 - cardW - cardGap / 2;
+        const rightCardX = W / 2 + cardGap / 2;
+
+        const drawWinnerCard = (contestant, label, x) => {
+            if (!contestant) return;
+            ctx.fillStyle = 'rgba(124,58,237,0.12)';
+            _rrect(ctx, x, cardY, cardW, cardH, 16);
+            ctx.fill();
+            ctx.strokeStyle = 'rgba(124,58,237,0.45)';
+            ctx.lineWidth = 1.5;
+            _rrect(ctx, x, cardY, cardW, cardH, 16);
+            ctx.stroke();
+
+            ctx.fillStyle = '#7c3aed';
+            ctx.font = '500 26px "Inter", "DM Sans", sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText(label, x + cardW / 2, cardY + 46);
+
+            ctx.fillStyle = '#f1f5f9';
+            ctx.font = 'bold 40px "Space Grotesk", "DM Sans", sans-serif';
+            const name = contestant.name.length > 13 ? contestant.name.slice(0, 12) + '…' : contestant.name;
+            ctx.fillText('👑 ' + name, x + cardW / 2, cardY + 114);
+
+            ctx.fillStyle = '#94a3b8';
+            ctx.font = '500 30px "DM Mono", monospace';
+            ctx.fillText(contestant.points + ' pts', x + cardW / 2, cardY + 162);
+        };
+
+        drawWinnerCard(topLead, 'Lead', leftCardX);
+        drawWinnerCard(topFollow, 'Follow', rightCardX);
+        afterWinnersY = cardY + cardH + 24;
+    }
+
+    drawDivider(afterWinnersY);
+
+    // Leaderboard
+    const colStartY = afterWinnersY + 16;
+    const PAD = 80;
+    const COL_GAP = 40;
+    const colW = (W - PAD * 2 - COL_GAP) / 2;
+    const leftColX = PAD;
+    const rightColX = PAD + colW + COL_GAP;
+
+    ctx.textAlign = 'left';
+    ctx.fillStyle = '#64748b';
+    ctx.font = '500 30px "Space Grotesk", "DM Sans", sans-serif';
+    ctx.fillText('Leads', leftColX, colStartY + 30);
+    ctx.fillText('Follows', rightColX, colStartY + 30);
+
+    const rowStartY = colStartY + 46;
+    const maxRows = Math.max(sortedLeads.length, sortedFollows.length);
+    const availH = H - rowStartY - 140;
+    const rowH = Math.max(52, Math.min(72, Math.floor(availH / Math.max(maxRows, 1))));
+    const nameFontSize = rowH >= 66 ? 34 : rowH >= 58 ? 30 : 26;
+
+    const drawRow = (contestant, x, i, isTop) => {
+        if (!contestant) return;
+        const y = rowStartY + i * rowH;
+
+        if (i % 2 === 0) {
+            ctx.fillStyle = 'rgba(255,255,255,0.025)';
+            ctx.fillRect(x - 8, y, colW + 8, rowH - 2);
+        }
+
+        ctx.fillStyle = '#475569';
+        ctx.font = `400 ${nameFontSize - 4}px "DM Mono", monospace`;
+        ctx.textAlign = 'left';
+        ctx.fillText((i + 1) + '.', x, y + rowH * 0.65);
+
+        const maxNameChars = Math.floor(colW / (nameFontSize * 0.58)) - 4;
+        const displayName = contestant.name.length > maxNameChars
+            ? contestant.name.slice(0, maxNameChars - 1) + '…'
+            : contestant.name;
+        ctx.fillStyle = isTop ? '#f1f5f9' : '#94a3b8';
+        ctx.font = isTop
+            ? `bold ${nameFontSize}px "DM Sans", sans-serif`
+            : `400 ${nameFontSize}px "DM Sans", sans-serif`;
+        ctx.fillText(displayName, x + 44, y + rowH * 0.65);
+
+        ctx.fillStyle = isTop ? '#7c3aed' : '#475569';
+        ctx.font = `bold ${nameFontSize}px "DM Mono", monospace`;
+        ctx.textAlign = 'right';
+        ctx.fillText(String(contestant.points), x + colW, y + rowH * 0.65);
+    };
+
+    for (let i = 0; i < maxRows; i++) {
+        drawRow(sortedLeads[i], leftColX, i, i === 0);
+        drawRow(sortedFollows[i], rightColX, i, i === 0);
+    }
+
+    // Bottom branding
+    drawDivider(H - 110);
+    ctx.fillStyle = '#334155';
+    ctx.font = '400 28px "Space Grotesk", "DM Sans", sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText("hustle n' tussle", W / 2, H - 56);
+
+    canvas.toBlob(blob => {
+        if (!blob) { showToast('Failed to generate image', 'error'); return; }
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'hnt-results.png';
+        document.body.appendChild(a);
+        a.click();
+        URL.revokeObjectURL(url);
+        document.body.removeChild(a);
+    }, 'image/png');
 }
 
 async function downloadBattleData() {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3339,11 +3339,11 @@ async function exportSocialImage() {
         ? Math.floor((badgeAreaW + badgeGap) / numRounds) - badgeGap
         : 48;
 
-    // rowH must satisfy both: fit all dancers and fit badge size
+    // rowH fills all available vertical space; badgeSize is the smaller of the two constraints
     const maxRowHFromSpace = maxDancers > 0 ? Math.floor(availForRows / (2 * maxDancers)) : 70;
-    const badgeSize = Math.max(16, Math.min(maxRowHFromSpace - 18, badgeSizeFromRounds));
-    const rowH = Math.max(36, Math.min(maxRowHFromSpace, badgeSize + 18));
-    const nameFontSize = Math.max(20, Math.min(32, rowH - 10));
+    const rowH = Math.max(36, maxRowHFromSpace);
+    const badgeSize = Math.max(16, Math.min(rowH - 18, badgeSizeFromRounds));
+    const nameFontSize = Math.max(20, Math.min(44, rowH - 26));
     const rankFontSize = Math.max(16, nameFontSize - 4);
 
     const drawSection = (order, map, topName, label, startY) => {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3282,17 +3282,24 @@ async function exportSocialImage() {
     // Badge sizing: fit all rounds on a single horizontal line per row
     const rankW = 44;
     const nameAreaW = 260;
-    const badgeStartX = PAD + rankW + nameAreaW + 12;
+    const badgeStartX = PAD + rankW + nameAreaW + 24;
     const badgeAreaW = W - PAD - badgeStartX;
     const badgeGap = 4;
-    const badgeSizeFromRounds = numRounds > 0
-        ? Math.floor((badgeAreaW + badgeGap) / numRounds) - badgeGap
-        : 48;
+
+    // Use the most rounds any individual dancer competed in (not total game rounds)
+    // so the badge row fills the full width for the most active dancer.
+    const allRoundCounts = [
+        ...[...leadsOrder].map(n => (resultsLeadMap.get(n) || []).length),
+        ...[...followsOrder].map(n => (resultsFollowMap.get(n) || []).length),
+    ];
+    const maxRoundsPerDancer = Math.max(...allRoundCounts, 1);
+    const badgeSizeFromRounds = Math.floor((badgeAreaW + badgeGap) / maxRoundsPerDancer) - badgeGap;
 
     // rowH fills all available vertical space; badgeSize is the smaller of the two constraints
     const maxRowHFromSpace = maxDancers > 0 ? Math.floor(availForRows / (2 * maxDancers)) : 70;
     const rowH = Math.max(36, maxRowHFromSpace);
     const badgeSize = Math.max(16, Math.min(rowH - 18, badgeSizeFromRounds));
+    const bFontSize = Math.max(9, Math.round(badgeSize * 0.52));
     const nameFontSize = Math.max(20, Math.min(44, rowH - 26));
     const rankFontSize = Math.max(16, nameFontSize - 4);
 
@@ -3321,7 +3328,11 @@ async function exportSocialImage() {
             ctx.textAlign = 'left';
             ctx.fillText((idx + 1) + '.', PAD, textBaseY);
 
-            // Name (truncated to fit)
+            // Name + crown — clipped to nameAreaW so crown never bleeds into badge area
+            ctx.save();
+            ctx.beginPath();
+            ctx.rect(PAD + rankW, rowY, nameAreaW, rowH);
+            ctx.clip();
             const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
             const displayName = name.length > maxChars ? name.slice(0, maxChars - 1) + '…' : name;
             ctx.fillStyle = isTop ? '#111111' : '#555555';
@@ -3329,13 +3340,12 @@ async function exportSocialImage() {
                 ? `bold ${nameFontSize}px "DM Sans",sans-serif`
                 : `400 ${nameFontSize}px "DM Sans",sans-serif`;
             ctx.fillText(displayName, PAD + rankW, textBaseY);
-
-            // Crown after name for winner
             if (isTop) {
                 const nameW2 = ctx.measureText(displayName).width;
                 ctx.font = `${nameFontSize}px serif`;
                 ctx.fillText('👑', PAD + rankW + nameW2 + 5, textBaseY);
             }
+            ctx.restore();
 
             // Round badges — one row of circles
             const rounds = (map.get(name) || []).slice().sort((a, b) => a.round - b.round);
@@ -3356,7 +3366,6 @@ async function exportSocialImage() {
                 ctx.lineWidth = 1.5;
                 ctx.stroke();
 
-                const bFontSize = Math.max(9, badgeSize - 13);
                 ctx.fillStyle = info.win ? '#ffffff' : '#aaaaaa';
                 ctx.font = `bold ${bFontSize}px "DM Mono",monospace`;
                 ctx.textAlign = 'center';


### PR DESCRIPTION
Adds a "Share Results (9:16)" button on the final results screen that
renders the leaderboard onto a 1080×1920 canvas and downloads it as a
PNG, sized correctly for Instagram Stories, TikTok, and similar formats.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CSGkn1M9THKPgwSSwi4i69