### PR TITLE
feat(export): theme-aware social image export

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -22,6 +22,7 @@ let resultsTopLeadName = null;
 let resultsTopFollowName = null;
 let resultsNumRounds = 0;
 let resultsGuestJudges = [];
+let resultsEventTitle = null; // custom subtitle; falls back to "Month Edition (Year)"
 
 // Display mode state (for viewer-only mode without voting controls)
 let displayMode = false;
@@ -3338,11 +3339,11 @@ async function exportSocialImage() {
     ctx.fillText("Hustle n' Tussle", W / 2, 130);
 
     const now = new Date();
-    const monthStr = now.toLocaleDateString('en-US', { month: 'long' });
-    const yearStr = now.getFullYear();
+    const subtitleText = resultsEventTitle
+        || `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
     ctx.fillStyle = C.textSecondary;
     ctx.font = `400 38px ${C.fontBody}`;
-    ctx.fillText(`${monthStr} Edition (${yearStr})`, W / 2, 200);
+    ctx.fillText(subtitleText, W / 2, 200);
 
     if (resultsGuestJudges.length > 0) {
         const judgeLabel = resultsGuestJudges.length === 1 ? 'Judge' : 'Judges';


### PR DESCRIPTION
## Summary

- Social image export now reads the app's current `data-color` attribute at export time and applies matching design tokens (blue accent + slate backgrounds in light mode; purple accent + navy backgrounds in dark mode) — card headers, badge fills, borders, and all text colors mirror the CSS design system
- Add `resultsEventTitle` global: when set, overrides the auto-generated "Month Edition (Year)" subtitle in the export with a custom event name
- Dynamic row height fills available canvas space based on dancer count; badge and name sizes scale proportionally

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSGkn1M9THKPgwSSwi4i69)_