### PR TITLE
Editable battle results, consistency warnings, and dancer merging

### DIFF
--- a/stats/__init__.py
+++ b/stats/__init__.py
@@ -1,11 +1,17 @@
 """Year-to-date stats: aggregation storage + battle-payload normalization."""
 
 from stats.normalize import normalize_battle
-from stats.stats_repository import StatsRepository, DuplicateBattleError, StatsError
+from stats.stats_repository import (
+    StatsRepository,
+    DuplicateBattleError,
+    DuplicateDancerError,
+    StatsError,
+)
 
 __all__ = [
     "normalize_battle",
     "StatsRepository",
     "DuplicateBattleError",
+    "DuplicateDancerError",
     "StatsError",
 ]

--- a/stats/stats_repository.py
+++ b/stats/stats_repository.py
@@ -33,6 +33,10 @@ class DuplicateBattleError(StatsError):
     """A battle with the same (name, date) was already submitted."""
 
 
+class DuplicateDancerError(StatsError):
+    """The requested display name collides with a different, unmerged dancer."""
+
+
 class StatsRepository:
     def __init__(self, database_url: str, min_connections: int = 1, max_connections: int = 5):
         if not PSYCOPG2_AVAILABLE:
@@ -55,6 +59,24 @@ class StatsRepository:
         with self._connection() as conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 cur.execute("SELECT id, display_name, aliases FROM dancers ORDER BY display_name")
+                return [dict(r) for r in cur.fetchall()]
+
+    def list_dancers_with_stats(self) -> List[Dict[str, Any]]:
+        """Like list_dancers, plus battle/result counts so an admin can spot likely
+        duplicate/orphaned dancers (e.g. a typo-fixed name left with zero battles)."""
+        with self._connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT d.id, d.display_name, d.aliases,
+                           COUNT(DISTINCT br.battle_id) AS battles_entered,
+                           COUNT(br.id) AS result_count
+                    FROM dancers d
+                    LEFT JOIN battle_results br ON br.dancer_id = d.id
+                    GROUP BY d.id
+                    ORDER BY d.display_name
+                    """
+                )
                 return [dict(r) for r in cur.fetchall()]
 
     def find_dancer_by_name(self, name: str) -> Optional[Dict[str, Any]]:
@@ -101,6 +123,104 @@ class StatsRepository:
             """,
             (alias, dancer_id, alias, alias),
         )
+
+    def merge_dancers(
+        self,
+        target_id: str,
+        source_ids: List[str],
+        new_display_name: Optional[str] = None,
+    ) -> int:
+        """
+        Fold one or more duplicate dancers into `target_id`: repoint their
+        battle_results, capture their names as aliases on the target, then delete
+        them. Optionally also rename the survivor to `new_display_name`.
+
+        Only battle_results.dancer_id and the dancers table are touched - each
+        battle's raw_data JSON is the immutable historical record and is
+        intentionally left as-is.
+
+        Returns the number of battle_results rows repointed.
+        """
+        if target_id in source_ids:
+            raise StatsError("Target dancer cannot also be a source.")
+
+        with self._connection() as conn:
+            try:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    all_ids = [target_id] + list(source_ids)
+
+                    cur.execute(
+                        "SELECT id, display_name, aliases FROM dancers WHERE id = ANY(%s::uuid[])",
+                        (all_ids,),
+                    )
+                    by_id = {str(r["id"]): r for r in cur.fetchall()}
+                    if len(by_id) != len(all_ids):
+                        raise StatsError("One or more selected dancers no longer exist.")
+
+                    # A blind repoint can't tell two dancers apart if they were both
+                    # (mistakenly, or legitimately as different people) entered as
+                    # separate contestants in the same battle+role - check the whole
+                    # merge set together, not just target-vs-each-source, since two
+                    # sources can collide with each other too.
+                    cur.execute(
+                        """
+                        SELECT br.battle_id, br.role, b.name, b.battle_date
+                        FROM battle_results br
+                        JOIN battles b ON b.id = br.battle_id
+                        WHERE br.dancer_id = ANY(%s::uuid[])
+                        GROUP BY br.battle_id, br.role, b.name, b.battle_date
+                        HAVING COUNT(DISTINCT br.dancer_id) > 1
+                        """,
+                        (all_ids,),
+                    )
+                    collisions = cur.fetchall()
+                    if collisions:
+                        battles_desc = ", ".join(f"{c['name']} ({c['battle_date']})" for c in collisions)
+                        raise StatsError(
+                            f"Cannot merge: {battles_desc} would end up with two results for the same battle and role."
+                        )
+
+                    cur.execute(
+                        "UPDATE battle_results SET dancer_id = %s WHERE dancer_id = ANY(%s::uuid[])",
+                        (target_id, source_ids),
+                    )
+                    moved = cur.rowcount
+
+                    for source_id in source_ids:
+                        source = by_id[source_id]
+                        self._maybe_add_alias(cur, target_id, source["display_name"])
+                        for alias in source["aliases"]:
+                            self._maybe_add_alias(cur, target_id, alias)
+
+                    cur.execute("DELETE FROM dancers WHERE id = ANY(%s::uuid[])", (source_ids,))
+
+                    new_name = (new_display_name or "").strip()
+                    target = by_id[target_id]
+                    if new_name and new_name.lower() != target["display_name"].strip().lower():
+                        old_name = target["display_name"]
+                        cur.execute(
+                            "UPDATE dancers SET display_name = %s WHERE id = %s",
+                            (new_name, target_id),
+                        )
+                        # Preserve the target's pre-rename name too, so it still resolves
+                        # via alias lookup on future uploads. Must run *after* the rename
+                        # above - _maybe_add_alias refuses to alias a name that still
+                        # equals the dancer's current display_name.
+                        self._maybe_add_alias(cur, target_id, old_name)
+
+                conn.commit()
+                return moved
+            except (StatsError, DuplicateDancerError):
+                conn.rollback()
+                raise
+            except psycopg2.errors.UniqueViolation as exc:
+                conn.rollback()
+                if "idx_dancers_display_name_lower" in str(exc):
+                    raise DuplicateDancerError("Another dancer already has that name.") from exc
+                raise StatsError(str(exc)) from exc
+            except Exception as exc:  # noqa: BLE001
+                conn.rollback()
+                raise StatsError(str(exc)) from exc
 
     # ----- battles -----
 
@@ -241,9 +361,7 @@ class StatsRepository:
                     cur.execute("DELETE FROM battle_results WHERE battle_id = %s", (battle_id,))
 
                     for row in results:
-                        dancer_id = existing_by_name.get(row["name"]) or self._get_or_create_dancer(
-                            cur, row["name"]
-                        )
+                        dancer_id = existing_by_name.get(row["name"]) or self._get_or_create_dancer(cur, row["name"])
                         cur.execute(
                             """
                             INSERT INTO battle_results
@@ -266,9 +384,7 @@ class StatsRepository:
             except psycopg2.errors.UniqueViolation as exc:
                 conn.rollback()
                 if "uq_battles_name_date" in str(exc):
-                    raise DuplicateBattleError(
-                        "Another battle with this name and date already exists."
-                    ) from exc
+                    raise DuplicateBattleError("Another battle with this name and date already exists.") from exc
                 raise StatsError(str(exc)) from exc
             except Exception as exc:  # noqa: BLE001
                 conn.rollback()

--- a/stats/stats_repository.py
+++ b/stats/stats_repository.py
@@ -185,6 +185,95 @@ class StatsRepository:
                 conn.rollback()
                 raise StatsError(str(exc)) from exc
 
+    def get_battle(self, battle_id: str) -> Optional[Dict[str, Any]]:
+        with self._connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT id, name, battle_date, battle_year, source, session_id, raw_data, created_at
+                    FROM battles WHERE id = %s
+                    """,
+                    (battle_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+    def update_battle(
+        self,
+        battle_id: str,
+        meta: Dict[str, Any],
+        raw_data: Dict[str, Any],
+        results: List[Dict[str, Any]],
+    ) -> bool:
+        """
+        Replace a battle's stored payload and results in place.
+
+        meta: {name, battle_date}
+        results: rows from normalize_battle (name, role, points, placement, is_winner, round_wins)
+
+        Unlike create_battle, there's no `resolutions` step here - a dancer name that
+        already appears in this battle's results keeps its existing dancer_id (so a
+        typo fix doesn't sever the link to their YTD history), and any new/renamed
+        name falls back to the same case-insensitive find-or-create as an unmapped
+        name during initial ingest.
+        """
+        with self._connection() as conn:
+            try:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    cur.execute(
+                        "SELECT dancer_name, dancer_id FROM battle_results WHERE battle_id = %s",
+                        (battle_id,),
+                    )
+                    existing_by_name = {r["dancer_name"]: r["dancer_id"] for r in cur.fetchall()}
+
+                    cur.execute(
+                        """
+                        UPDATE battles SET name = %s, battle_date = %s, raw_data = %s
+                        WHERE id = %s
+                        RETURNING id
+                        """,
+                        (meta["name"], meta["battle_date"], Json(raw_data), battle_id),
+                    )
+                    if cur.fetchone() is None:
+                        conn.rollback()
+                        return False
+
+                    cur.execute("DELETE FROM battle_results WHERE battle_id = %s", (battle_id,))
+
+                    for row in results:
+                        dancer_id = existing_by_name.get(row["name"]) or self._get_or_create_dancer(
+                            cur, row["name"]
+                        )
+                        cur.execute(
+                            """
+                            INSERT INTO battle_results
+                                (battle_id, dancer_id, dancer_name, role, points, placement, is_winner, round_wins)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                            """,
+                            (
+                                battle_id,
+                                dancer_id,
+                                row["name"],
+                                row["role"],
+                                row.get("points", 0),
+                                row.get("placement"),
+                                row.get("is_winner", False),
+                                row.get("round_wins", 0),
+                            ),
+                        )
+                conn.commit()
+                return True
+            except psycopg2.errors.UniqueViolation as exc:
+                conn.rollback()
+                if "uq_battles_name_date" in str(exc):
+                    raise DuplicateBattleError(
+                        "Another battle with this name and date already exists."
+                    ) from exc
+                raise StatsError(str(exc)) from exc
+            except Exception as exc:  # noqa: BLE001
+                conn.rollback()
+                raise StatsError(str(exc)) from exc
+
     def list_years(self) -> List[int]:
         with self._connection() as conn:
             with conn.cursor() as cur:

--- a/web/app.py
+++ b/web/app.py
@@ -30,7 +30,13 @@ from persistence import (  # noqa: E402
     MemoryGameRepository,
 )
 from werkzeug.security import check_password_hash  # noqa: E402
-from stats import StatsRepository, normalize_battle, DuplicateBattleError, StatsError  # noqa: E402
+from stats import (  # noqa: E402
+    StatsRepository,
+    normalize_battle,
+    DuplicateBattleError,
+    DuplicateDancerError,
+    StatsError,
+)
 
 # Set up logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -1983,6 +1989,44 @@ def stats_update_battle(battle_id):
     if not updated:
         return jsonify({"error": "Battle not found"}), 404
     return jsonify({"success": True})
+
+
+@app.route("/api/stats/dancers", methods=["GET"])
+@admin_required
+def stats_list_dancers():
+    if stats_repo is None:
+        return jsonify({"error": "Stats database not configured"}), 503
+    dancers = stats_repo.list_dancers_with_stats()
+    for d in dancers:
+        d["id"] = str(d["id"])
+        d["battles_entered"] = int(d.get("battles_entered") or 0)
+        d["result_count"] = int(d.get("result_count") or 0)
+    return jsonify({"dancers": dancers})
+
+
+@app.route("/api/stats/dancers/merge", methods=["POST"])
+@admin_required
+def stats_merge_dancers():
+    """Fold one or more duplicate dancers into a single survivor."""
+    if stats_repo is None:
+        return jsonify({"error": "Stats database not configured"}), 503
+    data = request.get_json(silent=True) or {}
+    target_id = data.get("target_id")
+    source_ids = data.get("source_ids") or []
+    new_display_name = data.get("new_display_name")
+
+    if not target_id or not isinstance(source_ids, list) or not source_ids:
+        return jsonify({"error": "target_id and a non-empty source_ids list are required"}), 400
+    if target_id in source_ids:
+        return jsonify({"error": "Target dancer cannot also be a source."}), 400
+
+    try:
+        moved = stats_repo.merge_dancers(target_id, source_ids, new_display_name)
+    except DuplicateDancerError as e:
+        return jsonify({"error": str(e)}), 409
+    except StatsError as e:
+        return jsonify({"error": str(e)}), 400
+    return jsonify({"success": True, "battle_results_moved": moved})
 
 
 @app.route("/api/results", methods=["GET"])

--- a/web/app.py
+++ b/web/app.py
@@ -1932,6 +1932,59 @@ def stats_delete_battle(battle_id):
     return jsonify({"success": True})
 
 
+@app.route("/api/stats/battles/<battle_id>", methods=["GET"])
+@admin_required
+def stats_get_battle(battle_id):
+    """Fetch a single committed battle's full raw payload, for the edit modal."""
+    if stats_repo is None:
+        return jsonify({"error": "Stats database not configured"}), 503
+    battle = stats_repo.get_battle(battle_id)
+    if not battle:
+        return jsonify({"error": "Battle not found"}), 404
+    battle["id"] = str(battle["id"])
+    battle["battle_date"] = battle["battle_date"].isoformat() if battle.get("battle_date") else None
+    battle["created_at"] = battle["created_at"].isoformat() if battle.get("created_at") else None
+    return jsonify(battle)
+
+
+@app.route("/api/stats/battles/<battle_id>", methods=["PUT"])
+@admin_required
+def stats_update_battle(battle_id):
+    """Replace a committed battle's payload and re-derive its results.
+
+    Unlike /ingest/commit, the client only ever holds the edited raw payload (no
+    separate pre-normalized results list survives client-side editing), so results
+    are always recomputed here from raw_payload via normalize_battle - never
+    trust a client-supplied results array for this route.
+    """
+    if stats_repo is None:
+        return jsonify({"error": "Stats database not configured"}), 503
+    data = request.get_json(silent=True) or {}
+    name = (data.get("battle_name") or "").strip()
+    battle_date = (data.get("battle_date") or "").strip()
+    raw_payload = data.get("raw_payload") or {}
+
+    if not name or not battle_date or not raw_payload:
+        return jsonify({"error": "battle_name, battle_date and raw_payload are required"}), 400
+
+    try:
+        parse_battle_json(raw_payload)  # validate format/version (raises ValueError)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    norm = normalize_battle(raw_payload)
+    meta = {"name": name, "battle_date": battle_date}
+    try:
+        updated = stats_repo.update_battle(battle_id, meta, raw_payload, norm["results"])
+    except DuplicateBattleError as e:
+        return jsonify({"error": str(e)}), 409
+    except StatsError as e:
+        return jsonify({"error": str(e)}), 400
+    if not updated:
+        return jsonify({"error": "Battle not found"}), 404
+    return jsonify({"success": True})
+
+
 @app.route("/api/results", methods=["GET"])
 def get_results():
     """Read-only battle results for a session (for deep-linking /results/<id>).

--- a/web/index.html
+++ b/web/index.html
@@ -566,6 +566,19 @@
                 <div class="modal-body">
                     <p class="modal-note">Fix missing or incorrect names, points, champions, and round winners from the uploaded file. Changes apply to this view and to the downloadable JSON, not to the original file.</p>
 
+                    <div id="edit-results-meta" class="edit-results-section" style="display:none;">
+                        <div class="edit-results-champions">
+                            <div class="form-group">
+                                <label for="edit-battle-name">Battle name</label>
+                                <input type="text" id="edit-battle-name">
+                            </div>
+                            <div class="form-group">
+                                <label for="edit-battle-date">Battle date</label>
+                                <input type="date" id="edit-battle-date">
+                            </div>
+                        </div>
+                    </div>
+
                     <div class="edit-results-section">
                         <h4>Leads</h4>
                         <table class="results-table edit-results-table">

--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,8 @@
         .ytd-ingest-meta > div { flex: 1; min-width: 180px; }
         .ytd-resolve-wrap { max-height: 40vh; overflow: auto; margin-top: .5rem; }
         .ytd-resolve-wrap select, .ytd-resolve-wrap input[type=text] { width: 100%; padding: .35rem; border-radius: 6px; box-sizing: border-box; }
+        #ytd-merge-choices { display: flex; flex-direction: column; gap: .4rem; margin: .5rem 0; }
+        #ytd-merge-choices label { display: flex; align-items: center; gap: .5rem; margin: 0; font-size: .95rem; opacity: 1; }
     </style>
 </head>
 <body>
@@ -686,6 +688,14 @@
                     <thead><tr><th>Date</th><th>Name</th><th>Source</th><th>Results</th><th></th></tr></thead>
                     <tbody id="ytd-battles-body"></tbody>
                 </table>
+
+                <h4>Dancers</h4>
+                <p class="note">Select two or more of the same person (e.g. a typo'd name left behind after an edit) and merge them into one identity.</p>
+                <table class="results-table">
+                    <thead><tr><th></th><th>Name</th><th>Aliases</th><th>Battles</th></tr></thead>
+                    <tbody id="ytd-dancers-body"></tbody>
+                </table>
+                <button id="ytd-merge-selected-btn" class="btn secondary small" disabled>Merge Selected</button>
             </div>
 
             <div class="results-actions">
@@ -735,6 +745,22 @@
             <div class="ytd-modal-actions">
                 <button id="ytd-ingest-commit" class="btn primary">Publish</button>
                 <button id="ytd-ingest-cancel" class="btn secondary">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Merge dancers modal -->
+    <div id="ytd-merge-modal" class="ytd-modal hidden">
+        <div class="ytd-modal-card">
+            <h3>Merge Dancers</h3>
+            <p class="note">Choose which name becomes the canonical one. All others merge into it and are removed.</p>
+            <div id="ytd-merge-choices"></div>
+            <label for="ytd-merge-name">Canonical name</label>
+            <input type="text" id="ytd-merge-name">
+            <div id="ytd-merge-error" class="error-message"></div>
+            <div class="ytd-modal-actions">
+                <button id="ytd-merge-confirm" class="btn primary">Merge</button>
+                <button id="ytd-merge-cancel" class="btn secondary">Cancel</button>
             </div>
         </div>
     </div>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3,6 +3,14 @@ let sessionId = null;
 let liveBattleActive = false;      // a battle is live in-memory (skip refetch on route enter)
 let currentResultsData = null;     // last rendered results payload (for /results hydration)
 let currentUploadedBattlePayload = null; // raw hustlentussle.battle payload for the uploaded file being viewed/edited
+
+// State for the generalized battle-payload editor (#edit-results-modal). Kept separate from
+// currentUploadedBattlePayload since the same modal is also used to edit already-published
+// YTD battles (see web/js/ytd.js) - reusing that variable here would corrupt whichever flow
+// isn't currently using the modal (the results-screen download button, the edit-button
+// visibility gate, etc. all key off currentUploadedBattlePayload).
+let editorPayload = null;
+let editorCallbacks = null;
 let guestJudges = [];
 let leadVotes = {};  // Changed to an object to easily update votes
 let followVotes = {}; // Changed to an object to easily update votes
@@ -474,7 +482,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const editResultsSaveBtn = document.getElementById('edit-results-save');
     const editAddLeadBtn = document.getElementById('edit-add-lead');
     const editAddFollowBtn = document.getElementById('edit-add-follow');
-    if (editResultsBtn) editResultsBtn.addEventListener('click', openEditResultsModal);
+    if (editResultsBtn) {
+        editResultsBtn.addEventListener('click', () => {
+            openEditResultsModal(currentUploadedBattlePayload, {
+                title: 'Edit Results',
+                showMetaFields: false,
+                onSave: async (payload) => {
+                    const reprocessed = await reprocessBattlePayload(payload);
+                    currentUploadedBattlePayload = payload;
+                    reprocessed.uploaded = true;
+                    showResults(reprocessed, { sessionId: null });
+                    showToast('Results updated', 'success');
+                },
+            });
+        });
+    }
     if (editResultsCloseBtn) editResultsCloseBtn.addEventListener('click', closeEditResultsModal);
     if (editResultsCancelBtn) editResultsCancelBtn.addEventListener('click', closeEditResultsModal);
     if (editResultsSaveBtn) editResultsSaveBtn.addEventListener('click', saveEditedResults);
@@ -2730,12 +2752,34 @@ function computePlacements(entries) {
     });
 }
 
-function openEditResultsModal() {
-    if (!currentUploadedBattlePayload) return;
-    const payload = currentUploadedBattlePayload;
+// Generalized battle-payload editor. `payload` is a raw hustlentussle.battle v1 object;
+// `options.onSave(editedPayload, meta)` decides what "save" means for the caller (e.g. the
+// results screen reprocesses+redisplays locally, while the YTD admin screen PUTs to the
+// server) - see editorCallbacks usage in saveEditedResults(). `options.showMetaFields` shows
+// battle name/date inputs (only meaningful for already-published battles, which have a
+// separate DB-level name/date from the payload itself); `options.initialMeta` pre-fills them.
+function openEditResultsModal(payload, options = {}) {
+    if (!payload) return;
+    editorPayload = payload;
+    editorCallbacks = options;
+
     payload.participants = payload.participants || { leads: [], follows: [] };
     payload.participants.leads = payload.participants.leads || [];
     payload.participants.follows = payload.participants.follows || [];
+
+    const titleEl = document.getElementById('edit-results-title');
+    if (titleEl) titleEl.textContent = options.title || 'Edit Results';
+
+    const metaSection = document.getElementById('edit-results-meta');
+    if (metaSection) {
+        metaSection.style.display = options.showMetaFields ? '' : 'none';
+        if (options.showMetaFields) {
+            const nameInput = document.getElementById('edit-battle-name');
+            const dateInput = document.getElementById('edit-battle-date');
+            if (nameInput) nameInput.value = (options.initialMeta && options.initialMeta.name) || '';
+            if (dateInput) dateInput.value = (options.initialMeta && options.initialMeta.battle_date) || '';
+        }
+    }
 
     renderEditParticipants('edit-leads-body', payload.participants.leads);
     renderEditParticipants('edit-follows-body', payload.participants.follows);
@@ -2749,6 +2793,10 @@ function openEditResultsModal() {
     const modal = document.getElementById('edit-results-modal');
     if (modal) modal.classList.remove('hidden');
 }
+// Exposed so other modules (e.g. web/js/ytd.js, which is intentionally self-contained and
+// doesn't share scope with this file) can reuse this editor without duplicating its ~250
+// lines of table/select-building logic.
+window.openBattlePayloadEditor = openEditResultsModal;
 
 // Recomputes the points-vs-round-wins warning from whatever is currently typed/selected
 // in the modal (not the saved payload), so it updates live as the user edits.
@@ -2939,8 +2987,8 @@ async function saveEditedResults() {
     const errorEl = document.getElementById('edit-results-error');
     if (errorEl) { errorEl.textContent = ''; errorEl.classList.add('hidden'); }
 
-    const payload = currentUploadedBattlePayload;
-    if (!payload) return;
+    const payload = editorPayload;
+    if (!payload || !editorCallbacks) return;
 
     try {
         const leadEdits = collectParticipantEdits('edit-leads-body');
@@ -2981,12 +3029,14 @@ async function saveEditedResults() {
         applyParticipantEdits(payload, 'leads', leadEdits.entries, finalLeadChampion);
         applyParticipantEdits(payload, 'follows', followEdits.entries, finalFollowChampion);
 
-        const reprocessed = await reprocessBattlePayload(payload);
-        currentUploadedBattlePayload = payload;
-        reprocessed.uploaded = true;
+        const meta = editorCallbacks.showMetaFields
+            ? {
+                name: document.getElementById('edit-battle-name').value.trim(),
+                battle_date: document.getElementById('edit-battle-date').value,
+            }
+            : null;
+        await editorCallbacks.onSave(payload, meta);
         closeEditResultsModal();
-        showResults(reprocessed, { sessionId: null });
-        showToast('Results updated', 'success');
     } catch (err) {
         if (errorEl) {
             errorEl.textContent = err.message || 'Failed to save changes.';

--- a/web/js/ytd.js
+++ b/web/js/ytd.js
@@ -176,6 +176,116 @@
         });
     }
 
+    // ---- admin: dancers (merge duplicates) ----
+
+    let mergeNameDirty = false; // true once the admin has typed into #ytd-merge-name themselves
+
+    async function loadDancers() {
+        if (!isAdmin) return;
+        let dancers = [];
+        try {
+            const res = await fetch('/api/stats/dancers');
+            dancers = (await res.json()).dancers || [];
+        } catch (e) { dancers = []; }
+        const body = $('ytd-dancers-body');
+        body.innerHTML = '';
+        dancers.forEach((d) => {
+            const tr = document.createElement('tr');
+            const checkCell = document.createElement('td');
+            const check = document.createElement('input');
+            check.type = 'checkbox';
+            check.dataset.id = d.id;
+            check.dataset.name = d.display_name;
+            checkCell.appendChild(check);
+            tr.appendChild(checkCell);
+
+            const nameCell = document.createElement('td');
+            nameCell.textContent = d.display_name;
+            tr.appendChild(nameCell);
+
+            const aliasCell = document.createElement('td');
+            aliasCell.textContent = (d.aliases || []).join(', ');
+            tr.appendChild(aliasCell);
+
+            const battlesCell = document.createElement('td');
+            battlesCell.textContent = d.battles_entered;
+            if (d.battles_entered === 0) {
+                const hint = document.createElement('span');
+                hint.style.color = 'var(--text-muted, #888)';
+                hint.textContent = ' (no battles)';
+                battlesCell.appendChild(hint);
+            }
+            tr.appendChild(battlesCell);
+
+            body.appendChild(tr);
+        });
+        updateMergeButtonState();
+    }
+
+    function updateMergeButtonState() {
+        const checked = $('ytd-dancers-body').querySelectorAll('input[type=checkbox]:checked');
+        $('ytd-merge-selected-btn').disabled = checked.length < 2;
+    }
+
+    function openMergeModal() {
+        const checked = Array.from($('ytd-dancers-body').querySelectorAll('input[type=checkbox]:checked'));
+        if (checked.length < 2) return;
+
+        mergeNameDirty = false;
+        $('ytd-merge-error').textContent = '';
+        const choices = $('ytd-merge-choices');
+        choices.innerHTML = '';
+
+        checked.forEach((cb, i) => {
+            const label = document.createElement('label');
+            const radio = document.createElement('input');
+            radio.type = 'radio';
+            radio.name = 'ytd-merge-target';
+            radio.value = cb.dataset.id;
+            radio.dataset.name = cb.dataset.name;
+            if (i === 0) radio.checked = true;
+            radio.addEventListener('change', () => {
+                if (!mergeNameDirty) $('ytd-merge-name').value = radio.dataset.name;
+            });
+            label.appendChild(radio);
+            label.appendChild(document.createTextNode(cb.dataset.name));
+            choices.appendChild(label);
+        });
+
+        $('ytd-merge-name').value = checked[0].dataset.name;
+        openModal('ytd-merge-modal');
+    }
+
+    async function confirmMerge() {
+        const errEl = $('ytd-merge-error');
+        errEl.textContent = '';
+
+        const targetRadio = $('ytd-merge-choices').querySelector('input[type=radio]:checked');
+        if (!targetRadio) { errEl.textContent = 'Choose a dancer to keep.'; return; }
+        const targetId = targetRadio.value;
+        const targetName = targetRadio.dataset.name;
+
+        const sourceIds = Array.from($('ytd-dancers-body').querySelectorAll('input[type=checkbox]:checked'))
+            .map((cb) => cb.dataset.id)
+            .filter((id) => id !== targetId);
+
+        const typedName = $('ytd-merge-name').value.trim();
+        const payload = { target_id: targetId, source_ids: sourceIds };
+        if (typedName && typedName !== targetName) payload.new_display_name = typedName;
+
+        const res = await fetch('/api/stats/dancers/merge', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        let data; try { data = await res.json(); } catch (e) { data = {}; }
+        if (!res.ok) { errEl.textContent = data.error || 'Failed to merge dancers.'; return; }
+
+        closeModal('ytd-merge-modal');
+        await loadDancers();
+        await loadStandings();
+    }
+
     // ---- ingest (preview -> resolve -> commit) ----
 
     async function previewFromFile() {
@@ -323,6 +433,7 @@
         closeModal('ytd-login-modal');
         $('ytd-login-password').value = '';
         await loadBattles();
+        await loadDancers();
     }
 
     async function logout() {
@@ -339,6 +450,7 @@
         await loadYears();
         await loadStandings();
         await loadBattles();
+        await loadDancers();
     }
     window.ytdOnEnterStats = enterStats;
 
@@ -366,6 +478,14 @@
         on('publish-to-ytd', 'click', previewFromLiveBattle);
         on('ytd-ingest-cancel', 'click', () => closeModal('ytd-ingest-modal'));
         on('ytd-ingest-commit', 'click', commitIngest);
+
+        // dancers (merge duplicates)
+        const dancersBody = $('ytd-dancers-body');
+        if (dancersBody) dancersBody.addEventListener('change', updateMergeButtonState);
+        on('ytd-merge-selected-btn', 'click', openMergeModal);
+        on('ytd-merge-cancel', 'click', () => closeModal('ytd-merge-modal'));
+        on('ytd-merge-confirm', 'click', confirmMerge);
+        on('ytd-merge-name', 'input', () => { mergeNameDirty = true; });
 
         // file name display
         on('ytd-file-input', 'change', () => {

--- a/web/js/ytd.js
+++ b/web/js/ytd.js
@@ -114,6 +114,11 @@
                 `<td>${escapeHtml(b.source)}</td>` +
                 `<td>${b.result_count}</td>`;
             const actions = document.createElement('td');
+            const edit = document.createElement('button');
+            edit.className = 'btn secondary small';
+            edit.textContent = 'Edit';
+            edit.addEventListener('click', () => editBattle(b.id));
+            actions.appendChild(edit);
             const del = document.createElement('button');
             del.className = 'btn secondary small';
             del.textContent = 'Delete';
@@ -133,6 +138,42 @@
         } else {
             alert('Failed to delete battle.');
         }
+    }
+
+    async function editBattle(id) {
+        let battle;
+        try {
+            const res = await fetch(`/api/stats/battles/${id}`);
+            if (!res.ok) throw new Error();
+            battle = await res.json();
+        } catch (e) {
+            alert('Failed to load battle.');
+            return;
+        }
+
+        window.openBattlePayloadEditor(battle.raw_data, {
+            title: 'Edit Published Battle',
+            showMetaFields: true,
+            initialMeta: { name: battle.name, battle_date: battle.battle_date },
+            onSave: async (editedPayload, meta) => {
+                const res = await fetch(`/api/stats/battles/${id}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        battle_name: meta.name,
+                        battle_date: meta.battle_date,
+                        raw_payload: editedPayload,
+                    }),
+                });
+                let data;
+                try { data = await res.json(); } catch (e) { data = {}; }
+                if (!res.ok) throw new Error(data.error || 'Failed to update battle.');
+                await loadYears();
+                await loadStandings();
+                await loadBattles();
+                alert('Battle updated.');
+            },
+        });
     }
 
     // ---- ingest (preview -> resolve -> commit) ----


### PR DESCRIPTION
## Summary

- **Edit uploaded battle results before publishing**: a new "Edit Results" modal on the results screen lets you fix contestant names, points, champions, and per-round winners in an uploaded battle JSON before it's published to Year-to-Date (YTD) stats.
- **Points-vs-round-wins consistency warning**: both the results screen and the edit modal flag any contestant whose recorded points don't match their actual round-win count, live as you edit — advisory only, doesn't block saving.
- **Tie-break rounds now survive upload**: `parse_battle_json` previously stripped tie-break round data on upload, causing it to render as a broken normal round; it's now preserved and rendered correctly.
- **Edit already-published battles**: admins can now edit a battle after it's been committed to YTD stats (previously the only option was deleting and re-publishing from scratch). Reuses the same editor UI via a new `window.openBattlePayloadEditor` entry point, backed by new `GET`/`PUT /api/stats/battles/<id>` routes.
- **Merge duplicate dancer records**: a new "Dancers" admin panel lets you select two or more dancer records (e.g. a typo'd name left behind after an edit) and merge them into one canonical identity, with names/aliases preserved and `battle_results` repointed. Handles same-battle name collisions safely (aborts the whole merge with a clear error rather than partially merging).

## Test plan

All changes were exercised end-to-end with Playwright against a real Postgres instance (in addition to the JS-only flows tested without a DB):

- [x] Upload a battle JSON with intentional mistakes, edit results, save, and confirm the results screen and downloadable JSON reflect the fix
- [x] Confirm the points-consistency warning appears/clears live as edits are made, both on the results screen and inside the edit modal
- [x] Confirm a tie-break round renders correctly (not as a broken normal round) after upload
- [x] Publish a battle to YTD stats with a mistake, edit it via the new admin flow, and confirm standings update immediately without a page reload
- [x] Confirm editing a battle's date across a year boundary correctly moves it between year views, and that a name/date collision with another battle surfaces a clean error without corrupting data
- [x] Merge two duplicate dancers (including a rename during merge) and confirm points consolidate correctly and both old names resolve to the merged identity on future uploads
- [x] Confirm merge collisions (two dancers both entered in the same battle+role, including a 3-way merge where the colliding pair are both non-target sources) are rejected cleanly with no partial database writes
- [x] Regression-tested the full suite after each change to confirm no breakage in earlier parts of this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0194zeUBvjctmr45oWHouzj2)_