### PR TITLE
Phase 2: migration ledger + prod deploy ordering fix

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -46,12 +46,19 @@ jobs:
           git checkout prod
           git reset --hard origin/prod
 
+      - name: Build image
+        run: |
+          cd /home/oat/projects/hustlentussle-prod
+          docker compose build
+
+      # Migrations must run from the freshly built image (compose run uses
+      # the last built image, so building first is load-bearing here).
       - name: Apply DB migrations
         run: |
           cd /home/oat/projects/hustlentussle-prod
           docker compose run --rm web python scripts/migrate.py
 
-      - name: Build and restart containers
+      - name: Restart containers
         run: |
           cd /home/oat/projects/hustlentussle-prod
-          docker compose up -d --build
+          docker compose up -d

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ python simulate_test.py
 
 # Production (self-hosted Docker stack — see DEPLOY.md)
 docker compose up -d --build
-docker compose run --rm web python scripts/migrate.py          # apply DB migrations
+docker compose run --rm web python scripts/migrate.py          # apply DB migrations (ledger-tracked; build image first)
 docker compose run --rm web python scripts/create_admin.py --email you@example.com
 
 # Production (bare gunicorn, no Docker)

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -55,8 +55,9 @@ to loopback so only the proxy can reach it.
 
 ```bash
 git pull
-docker compose up -d --build
-docker compose run --rm web python scripts/migrate.py   # if new migrations were added
+docker compose build                                    # build first: migrate runs from the new image
+docker compose run --rm web python scripts/migrate.py   # applies only unapplied migrations (schema_migrations ledger)
+docker compose up -d
 ```
 
 Data persists in the `hustlentussle_pgdata` volume across rebuilds and restarts.

--- a/migrations/0002_games.sql
+++ b/migrations/0002_games.sql
@@ -1,0 +1,17 @@
+-- Live-game session storage, previously created at runtime by
+-- persistence/postgres_repository.py. IF NOT EXISTS keeps this a no-op on
+-- databases where the runtime path already created the table.
+
+CREATE TABLE IF NOT EXISTS games (
+    session_id VARCHAR(64) PRIMARY KEY,
+    game_state JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- Index for expiration queries
+CREATE INDEX IF NOT EXISTS idx_games_expires_at ON games(expires_at);
+
+-- Index for JSONB queries (if needed later)
+CREATE INDEX IF NOT EXISTS idx_games_state ON games USING GIN(game_state);

--- a/persistence/postgres_repository.py
+++ b/persistence/postgres_repository.py
@@ -81,33 +81,22 @@ class PostgresGameRepository(GameRepositoryInterface):
         except psycopg2.Error as e:
             raise PersistenceError(f"Failed to connect to PostgreSQL: {e}")
 
-        # Initialize database schema
-        self._init_schema()
+        # Verify the schema exists (created by scripts/migrate.py, not here)
+        self._check_schema()
 
-    def _init_schema(self):
-        """Create the games table if it doesn't exist."""
-        # Execute each SQL statement separately for psycopg2 compatibility
-        statements = [
-            """
-            CREATE TABLE IF NOT EXISTS games (
-                session_id VARCHAR(64) PRIMARY KEY,
-                game_state JSONB NOT NULL,
-                created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-                updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-                expires_at TIMESTAMP WITH TIME ZONE NOT NULL
-            )
-            """,
-            # Index for expiration queries
-            "CREATE INDEX IF NOT EXISTS idx_games_expires_at ON games(expires_at)",
-            # Index for JSONB queries (if needed later)
-            "CREATE INDEX IF NOT EXISTS idx_games_state ON games USING GIN(game_state)",
-        ]
+    def _check_schema(self):
+        """Fail loudly if the games table is missing.
 
+        Schema is owned by migrations/ (applied via scripts/migrate.py);
+        creating it lazily here would hide schema drift.
+        """
         with self._get_connection() as conn:
             with conn.cursor() as cur:
-                for statement in statements:
-                    cur.execute(statement)
-            conn.commit()
+                cur.execute("SELECT to_regclass('games')")
+                if cur.fetchone()[0] is None:
+                    raise PersistenceError(
+                        "The 'games' table does not exist. Run migrations first: python scripts/migrate.py"
+                    )
 
     @contextmanager
     def _get_connection(self):

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """
 Apply SQL migrations in migrations/ (sorted by filename) to the database in
-$DATABASE_URL. Migrations are written to be idempotent (CREATE ... IF NOT
-EXISTS), so re-running is safe.
+$DATABASE_URL.
+
+Applied migrations are recorded in a schema_migrations ledger table and are
+never re-run, so migrations do not need to be idempotent. Each migration file
+is applied and recorded in a single transaction.
 
 Usage:
     DATABASE_URL=postgresql://... python scripts/migrate.py
@@ -18,6 +21,13 @@ import psycopg2
 
 MIGRATIONS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "migrations")
 
+LEDGER_DDL = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+"""
+
 
 def main() -> int:
     database_url = os.environ.get("DATABASE_URL")
@@ -32,15 +42,31 @@ def main() -> int:
 
     conn = psycopg2.connect(database_url)
     try:
-        for path in files:
+        with conn.cursor() as cur:
+            cur.execute(LEDGER_DDL)
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT filename FROM schema_migrations")
+            applied = {row[0] for row in cur.fetchall()}
+
+        pending = [p for p in files if os.path.basename(p) not in applied]
+        if not pending:
+            print(f"Up to date. {len(applied)} migration(s) already applied, nothing to do.")
+            return 0
+
+        for path in pending:
             name = os.path.basename(path)
             with open(path, "r", encoding="utf-8") as fh:
                 sql = fh.read()
             print(f"Applying {name} ...")
+            # The migration and its ledger row commit together: a failed
+            # migration leaves no record and the transaction rolls back.
             with conn.cursor() as cur:
                 cur.execute(sql)
+                cur.execute("INSERT INTO schema_migrations (filename) VALUES (%s)", (name,))
             conn.commit()
-        print(f"Done. Applied {len(files)} migration file(s).")
+        print(f"Done. Applied {len(pending)} migration file(s).")
     except Exception as exc:  # noqa: BLE001 - surface the failure clearly
         conn.rollback()
         print(f"ERROR applying migrations: {exc}", file=sys.stderr)


### PR DESCRIPTION
Stacked on #69 (Phase 1), which stacks on #68 (Phase 0). Merge in order.

## Changes

- **`schema_migrations` ledger**: `scripts/migrate.py` records each applied migration and skips already-applied files. Migration + ledger row commit in one transaction, so a failed migration leaves no record. Migrations no longer need to be idempotent — required before any future `ALTER TABLE`/backfill.
- **`migrations/0002_games.sql`**: the `games` table + indexes move from runtime creation (`PostgresGameRepository._init_schema`) into a tracked migration. The repository now raises a clear *"run scripts/migrate.py"* error if the table is missing, instead of silently recreating schema. `IF NOT EXISTS` keeps it a no-op on existing databases.
- **Deploy ordering fix**: `deploy-prod.yml` previously ran `docker compose run … migrate.py` *before* `up -d --build` — `compose run` uses the **old** image, so a commit shipping a new migration would migrate from stale files. Now: `build` → `migrate` → `up -d`. `DEPLOY.md` updated to match.

## Verification (against the dev Postgres on :5433)

- First run applies `0001` + `0002` and records both; second run is a no-op ("Up to date").
- Fresh scratch database: `PostgresGameRepository` raises the loud missing-table error before migrations; after `migrate.py`, game create/fetch round-trips fine.
- Full suite: 107 tests green; ruff clean.

Note for first prod deploy after merge: the existing prod DB gets `schema_migrations` created and both files recorded on first run (both are idempotent, so the re-apply is harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzXaPTBzzSBBd8SZTqmCSM