### PR TITLE
Phase 6a: TS foundation — types.ts, global.d.ts, router.ts, ytd.ts, UI smoke

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "description": "Build tooling for the Hustle n' Tussle frontend (esbuild transform + tsc typecheck)",
   "scripts": {
-    "build": "esbuild web/js/app.js web/js/router.js web/js/ytd.js web/js/explainers.js web/js/components/DebugTools.js --outdir=web/js/dist --outbase=web/js --sourcemap --target=es2020",
-    "watch": "esbuild web/js/app.js web/js/router.js web/js/ytd.js web/js/explainers.js web/js/components/DebugTools.js --outdir=web/js/dist --outbase=web/js --sourcemap --target=es2020 --watch",
+    "build": "esbuild web/js/app.js web/js/router.ts web/js/ytd.ts web/js/explainers.js web/js/components/DebugTools.js --outdir=web/js/dist --outbase=web/js --sourcemap --target=es2020",
+    "watch": "esbuild web/js/app.js web/js/router.ts web/js/ytd.ts web/js/explainers.js web/js/components/DebugTools.js --outdir=web/js/dist --outbase=web/js --sourcemap --target=es2020 --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint web/js"
   },

--- a/scripts/smoke_ui.py
+++ b/scripts/smoke_ui.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Browser-level smoke test of the core battle flow, driven through the real UI.
+
+Flow: setup -> start battle -> vote + submit two rounds -> undo -> re-vote ->
+end battle early -> results screen. Fails on any JS page error, console error
+or missing screen transition.
+
+Usage:
+    .venv-dev/bin/python scripts/smoke_ui.py [--base-url http://127.0.0.1:8091]
+
+Requires playwright + chromium (see requirements-dev.txt;
+`playwright install chromium-headless-shell` and, once per host,
+`sudo playwright install-deps chromium`).
+"""
+
+import argparse
+import sys
+
+from playwright.sync_api import sync_playwright
+
+
+def vote_all_judges(page, targets: dict) -> None:
+    """Vote for a fixed dancer per role with every judge.
+
+    Voting for the same dancer each round (round winners stay in) produces a
+    unique points leader, so end-early resolves without a tie-break. On the
+    first call, targets is filled with each role's option-1 dancer name.
+    """
+    for role, container in (("lead", "#lead-judges-container"), ("follow", "#follow-judges-container")):
+        rows = page.locator(f"{container} .judge-row")
+        if role not in targets:
+            targets[role] = rows.first.locator(".vote-chip:visible").first.inner_text().strip()
+        for i in range(rows.count()):
+            chips = rows.nth(i).locator(".vote-chip:visible")
+            target_chip = chips.get_by_text(targets[role], exact=True)
+            if target_chip.count() > 0:
+                target_chip.first.click()
+            else:
+                chips.first.click()
+
+
+def submit_votes(page) -> None:
+    page.click("#submit-votes")
+    page.wait_for_selector("#vote-confirm-modal:not(.hidden)", timeout=5000)
+    page.click("#vote-confirm-submit")
+    page.wait_for_selector("#vote-confirm-modal.hidden", state="attached", timeout=5000)
+
+
+def read_round_number(page) -> int:
+    return int(page.locator("#round-number").inner_text().strip())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8091")
+    parser.add_argument("--headed", action="store_true", help="run with a visible browser")
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=not args.headed)
+        page = browser.new_page()
+        page.on("pageerror", lambda e: errors.append(f"pageerror: {e}"))
+        page.on(
+            "console",
+            lambda m: errors.append(f"console.error: {m.text}") if m.type == "error" else None,
+        )
+
+        print(f"1. Setup screen at {args.base_url}/setup")
+        page.goto(f"{args.base_url}/setup", wait_until="networkidle")
+        assert page.locator("#setup-screen").is_visible(), "setup screen not visible"
+
+        page.fill("#lead-names", "Ada, Boris, Cleo, Dmitri")
+        page.fill("#follow-names", "Elena, Felix, Grace, Hugo")
+        page.fill("#judge-names", "JudgeOne, JudgeTwo")
+
+        print("2. Start battle")
+        page.click("#start-competition")
+        page.wait_for_selector("#battle-screen.active", timeout=8000)
+        assert "/battle/" in page.url, f"expected /battle/<id> url, got {page.url}"
+        assert read_round_number(page) == 1
+        targets: dict = {}
+
+        print("3. Vote + submit round 1")
+        vote_all_judges(page, targets)
+        submit_votes(page)
+        page.wait_for_function("document.querySelector('#round-number').textContent.trim() === '2'", timeout=8000)
+
+        print("4. Vote + submit round 2")
+        vote_all_judges(page, targets)
+        submit_votes(page)
+        page.wait_for_function("document.querySelector('#round-number').textContent.trim() === '3'", timeout=8000)
+
+        print("5. Undo round")
+        page.click("#undo-round")
+        page.wait_for_function("document.querySelector('#round-number').textContent.trim() === '2'", timeout=8000)
+
+        print("6. Re-vote round 2")
+        vote_all_judges(page, targets)
+        submit_votes(page)
+        page.wait_for_function("document.querySelector('#round-number').textContent.trim() === '3'", timeout=8000)
+
+        print("7. End battle early")
+        page.click("#end-battle-early")
+        page.wait_for_selector("#end-early-modal:not(.hidden)", timeout=5000)
+        page.click("#end-early-confirm")
+        page.wait_for_selector("#results-screen.active", timeout=8000)
+        assert "/results/" in page.url, f"expected /results/<id> url, got {page.url}"
+
+        print("8. Results render")
+        assert page.locator("#lead-results-body tr").count() > 0, "lead results table empty"
+        assert page.locator("#follow-results-body tr").count() > 0, "follow results table empty"
+        assert page.locator("#rounds-accordion").is_visible(), "rounds accordion not visible"
+
+        print("9. Stats screen (ytd)")
+        page.goto(f"{args.base_url}/stats", wait_until="networkidle")
+        page.wait_for_selector("#stats-screen.active", timeout=8000)
+        assert page.locator("#ytd-year-select option").count() > 0, "year selector empty"
+
+        browser.close()
+
+    if errors:
+        print("\nJS ERRORS DURING SMOKE:")
+        for e in errors:
+            print(" -", e)
+        return 1
+    print("\nUI SMOKE PASSED (start / 2 rounds / undo / re-vote / end-early / results, zero JS errors)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/js/global.d.ts
+++ b/web/js/global.d.ts
@@ -1,0 +1,52 @@
+/**
+ * The cross-file window surface shared by the classic scripts.
+ *
+ * Only symbols consumed across file boundaries belong here — app.js's ~90
+ * internal globals stay out on purpose; they become module-scoped as files
+ * are converted.
+ *
+ * All members are optional because script load order (and the lazy debug
+ * bootstrap in index.html) means any of them can be absent at call time.
+ */
+
+import type { BattleExportV1 } from './types';
+
+declare global {
+    interface Window {
+        // router.ts
+        navigate?: (path: string, opts?: { replace?: boolean }) => void;
+        renderRoute?: () => void;
+
+        // app.js (top-level function declarations become window properties)
+        showScreen?: (el: HTMLElement) => void;
+        hydrateBattleRoute?: (sessionId: string) => void;
+        hydrateResultsRoute?: (sessionId: string | null) => void;
+        openBattlePayloadEditor?: (
+            payload: BattleExportV1,
+            opts: {
+                title?: string;
+                showMetaFields?: boolean;
+                initialMeta?: { name?: string; battle_date?: string | null };
+                onSave: (
+                    editedPayload: BattleExportV1,
+                    meta: { name: string; battle_date: string },
+                ) => Promise<void>;
+            },
+        ) => void;
+        sessionId?: string | null;
+
+        // ytd.ts
+        ytdOnEnterStats?: () => void;
+
+        // components/DebugTools.js + the inline bootstrap in index.html
+        ENABLE_DEBUG_TOOLS?: boolean;
+        DebugTools?: new () => unknown;
+        debugTools?: { autoAdvance?: boolean } & Record<string, unknown>;
+
+        // Spotify Web Playback SDK (loaded on demand from sdk.scdn.co)
+        Spotify?: unknown;
+        onSpotifyWebPlaybackSDKReady?: () => void;
+    }
+}
+
+export {};

--- a/web/js/router.ts
+++ b/web/js/router.ts
@@ -3,19 +3,24 @@
  *
  * Maps clean URL paths to the app's screens and hydrates the session-bearing
  * screens (/battle/<id>, /results/<id>) so they are shareable and reloadable.
- * Relies on globals defined in app.js (classic scripts share one global scope):
- *   showScreen(el), hydrateBattleRoute(sid), hydrateResultsRoute(sid),
- *   and window.ytdOnEnterStats (from ytd.js).
+ * Cross-file calls go through window (app.js's top-level function
+ * declarations are window properties): showScreen, hydrateBattleRoute,
+ * hydrateResultsRoute, ytdOnEnterStats.
  */
 (function () {
     'use strict';
 
-    function activate(screenId) {
+    function activate(screenId: string): void {
         const el = document.getElementById(screenId);
-        if (el && typeof showScreen === 'function') showScreen(el);
+        if (el && typeof window.showScreen === 'function') window.showScreen(el);
     }
 
-    const routes = [
+    interface Route {
+        re: RegExp;
+        enter: (m: RegExpMatchArray) => void;
+    }
+
+    const routes: Route[] = [
         { re: /^\/$/, enter: () => activate('home-screen') },
         { re: /^\/setup\/?$/, enter: () => activate('setup-screen') },
         { re: /^\/upload\/?$/, enter: () => activate('upload-screen') },
@@ -30,41 +35,43 @@
             re: /^\/battle\/([^/]+)\/?$/,
             enter: (m) => {
                 activate('battle-screen');
-                if (typeof hydrateBattleRoute === 'function') hydrateBattleRoute(decodeURIComponent(m[1]));
+                if (typeof window.hydrateBattleRoute === 'function') window.hydrateBattleRoute(decodeURIComponent(m[1]));
             },
         },
         {
             re: /^\/results\/([^/]+)\/?$/,
             enter: (m) => {
                 activate('results-screen');
-                if (typeof hydrateResultsRoute === 'function') hydrateResultsRoute(decodeURIComponent(m[1]));
+                if (typeof window.hydrateResultsRoute === 'function') {
+                    window.hydrateResultsRoute(decodeURIComponent(m[1]));
+                }
             },
         },
         {
             re: /^\/results\/?$/,
             enter: () => {
                 activate('results-screen');
-                if (typeof hydrateResultsRoute === 'function') hydrateResultsRoute(null);
+                if (typeof window.hydrateResultsRoute === 'function') window.hydrateResultsRoute(null);
             },
         },
     ];
 
-    function navigate(path, opts) {
-        opts = opts || {};
-        if (opts.replace) history.replaceState({}, '', path);
+    function navigate(path: string, opts?: { replace?: boolean }): void {
+        if (opts && opts.replace) history.replaceState({}, '', path);
         else history.pushState({}, '', path);
         renderRoute();
     }
 
-    function renderRoute() {
+    function renderRoute(): void {
         const path = window.location.pathname || '/';
 
         // Back-compat: legacy viewer link /?mode=display&session_id=X becomes
         // the new path form /battle/X?mode=display (keeps old QR codes working).
         if (path === '/') {
             const params = new URLSearchParams(window.location.search);
-            if (params.get('mode') === 'display' && params.get('session_id')) {
-                navigate('/battle/' + encodeURIComponent(params.get('session_id')) + '?mode=display', { replace: true });
+            const sid = params.get('session_id');
+            if (params.get('mode') === 'display' && sid) {
+                navigate('/battle/' + encodeURIComponent(sid) + '?mode=display', { replace: true });
                 return;
             }
         }
@@ -84,7 +91,7 @@
     window.renderRoute = renderRoute;
 
     window.addEventListener('popstate', renderRoute);
-    // Runs after app.js / ytd.js DOMContentLoaded handlers (script order), so their
+    // Runs after app.js / ytd.ts DOMContentLoaded handlers (script order), so their
     // element setup and detectDisplayMode() have already executed.
     document.addEventListener('DOMContentLoaded', renderRoute);
 })();

--- a/web/js/types.ts
+++ b/web/js/types.ts
@@ -1,0 +1,258 @@
+/**
+ * Shared API payload types — the single home for response/request shapes
+ * exchanged with the Flask backend (see web/routes/*.py).
+ *
+ * Types only: this file must never emit runtime code. Consume it with
+ * `import type { ... } from './types'` so esbuild erases the import.
+ */
+
+// ---- Year-to-date stats + admin (web/routes/admin_stats.py) ----
+
+export interface AdminMeResponse {
+    authenticated: boolean;
+    email?: string | null;
+}
+
+export interface AdminLoginResponse {
+    authenticated?: boolean;
+    email?: string;
+    error?: string;
+}
+
+export interface YtdStandingRow {
+    dancer_id: string;
+    display_name: string;
+    total_points: number;
+    crowns: number;
+    battles_entered: number;
+    round_wins: number;
+}
+
+export interface YtdStandingsResponse {
+    year: number;
+    leads: YtdStandingRow[];
+    follows: YtdStandingRow[];
+    error?: string;
+}
+
+export interface YtdYearsResponse {
+    years: number[];
+}
+
+export interface BattleSummary {
+    id: string;
+    name: string;
+    battle_date: string | null;
+    created_at: string | null;
+    source: 'live' | 'upload';
+    result_count: number;
+}
+
+export interface BattlesResponse {
+    battles: BattleSummary[];
+}
+
+export interface BattleDetail extends BattleSummary {
+    raw_data: BattleExportV1;
+}
+
+export interface DancerSummary {
+    id: string;
+    display_name: string;
+    aliases?: string[];
+    battles_entered: number;
+    result_count: number;
+}
+
+export interface DancersResponse {
+    dancers: DancerSummary[];
+    error?: string;
+}
+
+export interface NameResolutionProposal {
+    name: string;
+    suggested_dancer_id: string | null;
+    suggested_display_name: string;
+    is_new: boolean;
+}
+
+export interface NormalizedResultRow {
+    name: string;
+    role: 'lead' | 'follow';
+    points: number;
+    placement: number | null;
+    is_champion: boolean;
+    round_wins: number;
+}
+
+export interface IngestPreviewResponse {
+    source: 'live' | 'upload';
+    session_id: string | null;
+    results: NormalizedResultRow[];
+    names: NameResolutionProposal[];
+    dancers: Array<Pick<DancerSummary, 'id' | 'display_name'>>;
+    raw_payload: BattleExportV1;
+    error?: string;
+}
+
+/** Maps a battle-file name to an existing dancer id or a new dancer name. */
+export type NameResolutions = Record<string, { dancer_id: string } | { new_name: string }>;
+
+export interface ApiErrorResponse {
+    error: string;
+}
+
+// ---- Battle export file format (hustlentussle.battle v1) ----
+// Mirrors build_battle_export() / parse_battle_json() in web/helpers.py.
+
+export interface ChampionInfo {
+    name: string | null;
+    points: number | null;
+    decided_by: 'threshold' | 'tiebreak' | 'points' | null;
+}
+
+export interface Champions {
+    lead: ChampionInfo;
+    follow: ChampionInfo;
+}
+
+export interface ExportParticipant {
+    name: string;
+    points: number;
+    placement: number;
+    is_champion: boolean;
+    initial_order: number | null;
+}
+
+export interface RoundPairs {
+    pair_1: { lead: string; follow: string };
+    pair_2: { lead: string; follow: string };
+}
+
+export interface SongInfo {
+    track_name?: string | null;
+    artist_name?: string | null;
+    spotify_url?: string | null;
+    [key: string]: unknown;
+}
+
+export interface ExportRound {
+    round_num: number;
+    pairs: RoundPairs | null;
+    lead_winner: string | null;
+    follow_winner: string | null;
+    lead_votes: Record<string, number> | null;
+    follow_votes: Record<string, number> | null;
+    judges: string[] | null;
+    contestant_judges: string[] | null;
+    song: SongInfo | null;
+    tiebreak?: boolean;
+    tiebreak_leads?: string[];
+    tiebreak_follows?: string[];
+}
+
+export interface BattleExportV1 {
+    format: 'hustlentussle.battle';
+    version: 1;
+    session_id: string | null;
+    exported_at: string;
+    metadata: {
+        battle_date: string;
+        total_rounds: number;
+        win_threshold: number | null;
+        finished: boolean;
+        contestant_judging_enabled: boolean;
+    };
+    champions: Champions;
+    participants: {
+        leads: ExportParticipant[];
+        follows: ExportParticipant[];
+    };
+    judges: { guest: string[] };
+    rounds: ExportRound[];
+}
+
+// ---- Live game state (/api/state, web/helpers.py serialize_state) ----
+
+export interface ScoreboardRow {
+    name: string;
+    points: number;
+    is_winner: boolean;
+}
+
+export interface GameStateResponse {
+    session_id: string;
+    round: {
+        number: number;
+        pairs: RoundPairs;
+        judges: {
+            guest: string[];
+            contestant: string[];
+            simple_contestant_judges: boolean;
+            contestant_judging_enabled: boolean;
+            num_contestant_judges: number;
+            expected_contestant_judges: number;
+        };
+    };
+    scoreboard: { leads: ScoreboardRow[]; follows: ScoreboardRow[] };
+    rounds: Array<{
+        round_num: number;
+        pairs: RoundPairs | null;
+        lead_winner: string | null;
+        follow_winner: string | null;
+    }>;
+    thresholds: { win: number; auto_win: number };
+    flags: { has_winning_lead: boolean; has_winning_follow: boolean; finished: boolean };
+    winners: { lead: string | null; follow: string | null };
+    initial_order: { leads: string[]; follows: string[] };
+    queue_order: { leads: string[]; follows: string[] };
+    tiebreak: {
+        active: boolean;
+        sub_round: number;
+        lead_needed: boolean;
+        follow_needed: boolean;
+        tied_leads: string[];
+        tied_follows: string[];
+        sr1_pairings: Array<[string, string]>;
+        sr2_pairings: Array<[string, string]>;
+        lead_winner: string | null;
+        follow_winner: string | null;
+    };
+}
+
+// ---- Results (/api/results, /api/end_game — web/helpers.py format_end_game_results) ----
+
+export interface ResultRow {
+    name: string;
+    points: number;
+    medal: string;
+    is_winner: boolean;
+}
+
+export interface ResultsRound {
+    round_num: number;
+    session_id?: string;
+    pairs: RoundPairs | null;
+    lead_votes: Record<string, number> | null;
+    follow_votes: Record<string, number> | null;
+    judges: string[] | null;
+    contestant_judges: string[] | null;
+    win_messages: string[] | null;
+    lead_winner: string | null;
+    follow_winner: string | null;
+    song_info: SongInfo | null;
+    tiebreak?: boolean;
+    tiebreak_leads?: string[];
+    tiebreak_follows?: string[];
+}
+
+export interface ResultsResponse {
+    session_id: string;
+    leads: ResultRow[];
+    follows: ResultRow[];
+    rounds: ResultsRound[];
+    initial_leads: string[];
+    initial_follows: string[];
+    champions: Champions;
+    tiebreak_winners?: { lead: string | null; follow: string | null };
+}

--- a/web/js/ytd.ts
+++ b/web/js/ytd.ts
@@ -3,44 +3,56 @@
  * Self-contained; reuses the existing `.screen`/`.active` show pattern and
  * shared button/table classes. Talks to /api/stats/* and /api/admin/* .
  */
+import type {
+    AdminLoginResponse,
+    AdminMeResponse,
+    ApiErrorResponse,
+    BattleDetail,
+    BattlesResponse,
+    DancersResponse,
+    IngestPreviewResponse,
+    NameResolutions,
+    YtdStandingRow,
+    YtdStandingsResponse,
+    YtdYearsResponse,
+} from './types';
+
 (function () {
     'use strict';
 
-    const $ = (id) => document.getElementById(id);
+    const $ = <T extends HTMLElement = HTMLElement>(id: string): T => document.getElementById(id) as T;
 
     let isAdmin = false;
-    let preview = null; // { source, session_id, results, names, dancers, raw_payload }
+    let preview: IngestPreviewResponse | null = null;
 
     // ---- screen helpers ----
 
-    function showScreenById(screenId) {
-        document.querySelectorAll('.screen').forEach((s) => s.classList.remove('active'));
-        const el = $(screenId);
-        if (el) el.classList.add('active');
-        const nav = $('nav-bar');
-        if (nav) nav.style.display = screenId === 'home-screen' ? 'none' : '';
-        window.scrollTo(0, 0);
+    function openModal(id: string): void {
+        $(id).classList.remove('hidden');
     }
-
-    function openModal(id) { $(id).classList.remove('hidden'); }
-    function closeModal(id) { $(id).classList.add('hidden'); }
+    function closeModal(id: string): void {
+        $(id).classList.add('hidden');
+    }
 
     // ---- admin state ----
 
-    async function refreshAdmin() {
+    async function refreshAdmin(): Promise<void> {
         try {
             const res = await fetch('/api/admin/me');
-            const data = await res.json();
+            const data = (await res.json()) as AdminMeResponse;
             isAdmin = !!data.authenticated;
-            applyAdminUI(data.email);
-        } catch (e) {
+            applyAdminUI(data.email ?? null);
+        } catch {
             isAdmin = false;
             applyAdminUI(null);
         }
     }
 
-    function applyAdminUI(email) {
-        const set = (id, show) => { const el = $(id); if (el) el.style.display = show ? '' : 'none'; };
+    function applyAdminUI(email: string | null): void {
+        const set = (id: string, show: boolean) => {
+            const el = $(id);
+            if (el) el.style.display = show ? '' : 'none';
+        };
         set('ytd-admin-login-btn', !isAdmin);
         set('ytd-admin-logout-btn', isAdmin);
         set('ytd-admin-tools', isAdmin);
@@ -51,29 +63,34 @@
 
     // ---- standings ----
 
-    async function loadYears() {
-        const sel = $('ytd-year-select');
-        let years = [];
+    async function loadYears(): Promise<void> {
+        const sel = $<HTMLSelectElement>('ytd-year-select');
+        let years: number[] = [];
         try {
             const res = await fetch('/api/stats/years');
-            years = (await res.json()).years || [];
-        } catch (e) { years = []; }
+            years = ((await res.json()) as YtdYearsResponse).years || [];
+        } catch {
+            years = [];
+        }
         if (years.length === 0) years = [new Date().getFullYear()];
         sel.innerHTML = '';
         years.forEach((y) => {
             const opt = document.createElement('option');
-            opt.value = y; opt.textContent = y;
+            opt.value = String(y);
+            opt.textContent = String(y);
             sel.appendChild(opt);
         });
     }
 
-    async function loadStandings() {
-        const year = $('ytd-year-select').value;
-        let data = { leads: [], follows: [] };
+    async function loadStandings(): Promise<void> {
+        const year = $<HTMLSelectElement>('ytd-year-select').value;
+        let data: Pick<YtdStandingsResponse, 'leads' | 'follows'> = { leads: [], follows: [] };
         try {
             const res = await fetch(`/api/stats/year-to-date?year=${encodeURIComponent(year)}`);
-            if (res.ok) data = await res.json();
-        } catch (e) { /* keep empty */ }
+            if (res.ok) data = (await res.json()) as YtdStandingsResponse;
+        } catch {
+            /* keep empty */
+        }
 
         renderStandings('ytd-lead-body', data.leads || []);
         renderStandings('ytd-follow-body', data.follows || []);
@@ -81,12 +98,13 @@
         $('ytd-empty').style.display = empty ? '' : 'none';
     }
 
-    function renderStandings(bodyId, rows) {
+    function renderStandings(bodyId: string, rows: YtdStandingRow[]): void {
         const body = $(bodyId);
         body.innerHTML = '';
         rows.forEach((row, idx) => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${idx + 1}</td>` +
+            tr.innerHTML =
+                `<td>${idx + 1}</td>` +
                 `<td>${escapeHtml(row.display_name)}</td>` +
                 `<td>${row.total_points}</td>` +
                 `<td>${row.crowns || 0}</td>` +
@@ -97,19 +115,22 @@
 
     // ---- admin: contributed battles ----
 
-    async function loadBattles() {
+    async function loadBattles(): Promise<void> {
         if (!isAdmin) return;
-        const year = $('ytd-year-select').value;
-        let battles = [];
+        const year = $<HTMLSelectElement>('ytd-year-select').value;
+        let battles: BattlesResponse['battles'] = [];
         try {
             const res = await fetch(`/api/stats/battles?year=${encodeURIComponent(year)}`);
-            battles = (await res.json()).battles || [];
-        } catch (e) { battles = []; }
+            battles = ((await res.json()) as BattlesResponse).battles || [];
+        } catch {
+            battles = [];
+        }
         const body = $('ytd-battles-body');
         body.innerHTML = '';
         battles.forEach((b) => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${escapeHtml(b.battle_date || '')}</td>` +
+            tr.innerHTML =
+                `<td>${escapeHtml(b.battle_date || '')}</td>` +
                 `<td>${escapeHtml(b.name)}</td>` +
                 `<td>${escapeHtml(b.source)}</td>` +
                 `<td>${b.result_count}</td>`;
@@ -129,7 +150,7 @@
         });
     }
 
-    async function deleteBattle(id, name) {
+    async function deleteBattle(id: string, name: string): Promise<void> {
         if (!confirm(`Delete "${name}"? This removes its results from the stats.`)) return;
         const res = await fetch(`/api/stats/battles/${id}`, { method: 'DELETE' });
         if (res.ok) {
@@ -140,17 +161,21 @@
         }
     }
 
-    async function editBattle(id) {
-        let battle;
+    async function editBattle(id: string): Promise<void> {
+        let battle: BattleDetail;
         try {
             const res = await fetch(`/api/stats/battles/${id}`);
             if (!res.ok) throw new Error();
-            battle = await res.json();
-        } catch (e) {
+            battle = (await res.json()) as BattleDetail;
+        } catch {
             alert('Failed to load battle.');
             return;
         }
 
+        if (!window.openBattlePayloadEditor) {
+            alert('Battle editor is unavailable.');
+            return;
+        }
         window.openBattlePayloadEditor(battle.raw_data, {
             title: 'Edit Published Battle',
             showMetaFields: true,
@@ -165,8 +190,12 @@
                         raw_payload: editedPayload,
                     }),
                 });
-                let data;
-                try { data = await res.json(); } catch (e) { data = {}; }
+                let data: Partial<ApiErrorResponse>;
+                try {
+                    data = (await res.json()) as Partial<ApiErrorResponse>;
+                } catch {
+                    data = {};
+                }
                 if (!res.ok) throw new Error(data.error || 'Failed to update battle.');
                 await loadYears();
                 await loadStandings();
@@ -180,13 +209,15 @@
 
     let mergeNameDirty = false; // true once the admin has typed into #ytd-merge-name themselves
 
-    async function loadDancers() {
+    async function loadDancers(): Promise<void> {
         if (!isAdmin) return;
-        let dancers = [];
+        let dancers: DancersResponse['dancers'] = [];
         try {
             const res = await fetch('/api/stats/dancers');
-            dancers = (await res.json()).dancers || [];
-        } catch (e) { dancers = []; }
+            dancers = ((await res.json()) as DancersResponse).dancers || [];
+        } catch {
+            dancers = [];
+        }
         const body = $('ytd-dancers-body');
         body.innerHTML = '';
         dancers.forEach((d) => {
@@ -208,7 +239,7 @@
             tr.appendChild(aliasCell);
 
             const battlesCell = document.createElement('td');
-            battlesCell.textContent = d.battles_entered;
+            battlesCell.textContent = String(d.battles_entered);
             if (d.battles_entered === 0) {
                 const hint = document.createElement('span');
                 hint.style.color = 'var(--text-muted, #888)';
@@ -222,13 +253,15 @@
         updateMergeButtonState();
     }
 
-    function updateMergeButtonState() {
+    function updateMergeButtonState(): void {
         const checked = $('ytd-dancers-body').querySelectorAll('input[type=checkbox]:checked');
-        $('ytd-merge-selected-btn').disabled = checked.length < 2;
+        $<HTMLButtonElement>('ytd-merge-selected-btn').disabled = checked.length < 2;
     }
 
-    function openMergeModal() {
-        const checked = Array.from($('ytd-dancers-body').querySelectorAll('input[type=checkbox]:checked'));
+    function openMergeModal(): void {
+        const checked = Array.from(
+            $('ytd-dancers-body').querySelectorAll<HTMLInputElement>('input[type=checkbox]:checked'),
+        );
         if (checked.length < 2) return;
 
         mergeNameDirty = false;
@@ -241,36 +274,44 @@
             const radio = document.createElement('input');
             radio.type = 'radio';
             radio.name = 'ytd-merge-target';
-            radio.value = cb.dataset.id;
+            radio.value = cb.dataset.id || '';
             radio.dataset.name = cb.dataset.name;
             if (i === 0) radio.checked = true;
             radio.addEventListener('change', () => {
-                if (!mergeNameDirty) $('ytd-merge-name').value = radio.dataset.name;
+                if (!mergeNameDirty) $<HTMLInputElement>('ytd-merge-name').value = radio.dataset.name || '';
             });
             label.appendChild(radio);
-            label.appendChild(document.createTextNode(cb.dataset.name));
+            label.appendChild(document.createTextNode(cb.dataset.name || ''));
             choices.appendChild(label);
         });
 
-        $('ytd-merge-name').value = checked[0].dataset.name;
+        $<HTMLInputElement>('ytd-merge-name').value = checked[0].dataset.name || '';
         openModal('ytd-merge-modal');
     }
 
-    async function confirmMerge() {
+    async function confirmMerge(): Promise<void> {
         const errEl = $('ytd-merge-error');
         errEl.textContent = '';
 
-        const targetRadio = $('ytd-merge-choices').querySelector('input[type=radio]:checked');
-        if (!targetRadio) { errEl.textContent = 'Choose a dancer to keep.'; return; }
+        const targetRadio = $('ytd-merge-choices').querySelector<HTMLInputElement>('input[type=radio]:checked');
+        if (!targetRadio) {
+            errEl.textContent = 'Choose a dancer to keep.';
+            return;
+        }
         const targetId = targetRadio.value;
         const targetName = targetRadio.dataset.name;
 
-        const sourceIds = Array.from($('ytd-dancers-body').querySelectorAll('input[type=checkbox]:checked'))
-            .map((cb) => cb.dataset.id)
+        const sourceIds = Array.from(
+            $('ytd-dancers-body').querySelectorAll<HTMLInputElement>('input[type=checkbox]:checked'),
+        )
+            .map((cb) => cb.dataset.id || '')
             .filter((id) => id !== targetId);
 
-        const typedName = $('ytd-merge-name').value.trim();
-        const payload = { target_id: targetId, source_ids: sourceIds };
+        const typedName = $<HTMLInputElement>('ytd-merge-name').value.trim();
+        const payload: { target_id: string; source_ids: string[]; new_display_name?: string } = {
+            target_id: targetId,
+            source_ids: sourceIds,
+        };
         if (typedName && typedName !== targetName) payload.new_display_name = typedName;
 
         const res = await fetch('/api/stats/dancers/merge', {
@@ -278,8 +319,16 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
-        let data; try { data = await res.json(); } catch (e) { data = {}; }
-        if (!res.ok) { errEl.textContent = data.error || 'Failed to merge dancers.'; return; }
+        let data: Partial<ApiErrorResponse>;
+        try {
+            data = (await res.json()) as Partial<ApiErrorResponse>;
+        } catch {
+            data = {};
+        }
+        if (!res.ok) {
+            errEl.textContent = data.error || 'Failed to merge dancers.';
+            return;
+        }
 
         closeModal('ytd-merge-modal');
         await loadDancers();
@@ -288,19 +337,25 @@
 
     // ---- ingest (preview -> resolve -> commit) ----
 
-    async function previewFromFile() {
-        const input = $('ytd-file-input');
-        const file = input.files[0];
-        if (!file) { alert('Choose a .json battle file first.'); return; }
+    async function previewFromFile(): Promise<void> {
+        const input = $<HTMLInputElement>('ytd-file-input');
+        const file = input.files && input.files[0];
+        if (!file) {
+            alert('Choose a .json battle file first.');
+            return;
+        }
         const fd = new FormData();
         fd.append('battle_file', file);
         const res = await fetch('/api/stats/ingest/preview', { method: 'POST', body: fd });
         await handlePreviewResponse(res);
     }
 
-    async function previewFromLiveBattle() {
+    async function previewFromLiveBattle(): Promise<void> {
         const sid = localStorage.getItem('sessionId');
-        if (!sid) { alert('No active battle found to publish.'); return; }
+        if (!sid) {
+            alert('No active battle found to publish.');
+            return;
+        }
         const res = await fetch('/api/stats/ingest/preview', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -309,18 +364,26 @@
         await handlePreviewResponse(res);
     }
 
-    async function handlePreviewResponse(res) {
-        let data;
-        try { data = await res.json(); } catch (e) { data = {}; }
-        if (!res.ok) { alert(data.error || 'Failed to load battle for review.'); return; }
-        preview = data;
+    async function handlePreviewResponse(res: Response): Promise<void> {
+        let data: IngestPreviewResponse | Record<string, never>;
+        try {
+            data = (await res.json()) as IngestPreviewResponse;
+        } catch {
+            data = {};
+        }
+        if (!res.ok) {
+            alert(('error' in data && data.error) || 'Failed to load battle for review.');
+            return;
+        }
+        preview = data as IngestPreviewResponse;
         openIngestModal();
     }
 
-    function openIngestModal() {
+    function openIngestModal(): void {
+        if (!preview) return;
         $('ytd-ingest-error').textContent = '';
-        $('ytd-battle-name').value = '';
-        $('ytd-battle-date').value = new Date().toISOString().slice(0, 10);
+        $<HTMLInputElement>('ytd-battle-name').value = '';
+        $<HTMLInputElement>('ytd-battle-date').value = new Date().toISOString().slice(0, 10);
         const body = $('ytd-resolve-body');
         body.innerHTML = '';
 
@@ -340,7 +403,7 @@
             newOpt.textContent = '➕ Create new dancer';
             select.appendChild(newOpt);
 
-            preview.dancers.forEach((d) => {
+            preview!.dancers.forEach((d) => {
                 const opt = document.createElement('option');
                 opt.value = d.id;
                 opt.textContent = d.display_name;
@@ -369,23 +432,29 @@
         openModal('ytd-ingest-modal');
     }
 
-    async function commitIngest() {
-        const name = $('ytd-battle-name').value.trim();
-        const date = $('ytd-battle-date').value;
+    async function commitIngest(): Promise<void> {
+        if (!preview) return;
+        const name = $<HTMLInputElement>('ytd-battle-name').value.trim();
+        const date = $<HTMLInputElement>('ytd-battle-date').value;
         const errEl = $('ytd-ingest-error');
         errEl.textContent = '';
-        if (!name || !date) { errEl.textContent = 'Battle name and date are required.'; return; }
+        if (!name || !date) {
+            errEl.textContent = 'Battle name and date are required.';
+            return;
+        }
 
-        const resolutions = {};
-        $('ytd-resolve-body').querySelectorAll('select').forEach((sel) => {
-            const seen = sel.dataset.name;
-            if (sel.value) {
-                resolutions[seen] = { dancer_id: sel.value };
-            } else {
-                const input = sel.parentElement.querySelector('input[type=text]');
-                resolutions[seen] = { new_name: (input && input.value.trim()) || seen };
-            }
-        });
+        const resolutions: NameResolutions = {};
+        $('ytd-resolve-body')
+            .querySelectorAll('select')
+            .forEach((sel) => {
+                const seen = sel.dataset.name || '';
+                if (sel.value) {
+                    resolutions[seen] = { dancer_id: sel.value };
+                } else {
+                    const input = sel.parentElement && sel.parentElement.querySelector<HTMLInputElement>('input[type=text]');
+                    resolutions[seen] = { new_name: (input && input.value.trim()) || seen };
+                }
+            });
 
         const payload = {
             battle_name: name,
@@ -402,11 +471,19 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
         });
-        let data; try { data = await res.json(); } catch (e) { data = {}; }
-        if (!res.ok) { errEl.textContent = data.error || 'Failed to publish battle.'; return; }
+        let data: Partial<ApiErrorResponse>;
+        try {
+            data = (await res.json()) as Partial<ApiErrorResponse>;
+        } catch {
+            data = {};
+        }
+        if (!res.ok) {
+            errEl.textContent = data.error || 'Failed to publish battle.';
+            return;
+        }
 
         closeModal('ytd-ingest-modal');
-        $('ytd-file-input').value = '';
+        $<HTMLInputElement>('ytd-file-input').value = '';
         $('ytd-file-name').textContent = '';
         await loadYears();
         await loadStandings();
@@ -416,9 +493,9 @@
 
     // ---- admin login ----
 
-    async function submitLogin() {
-        const email = $('ytd-login-email').value.trim();
-        const password = $('ytd-login-password').value;
+    async function submitLogin(): Promise<void> {
+        const email = $<HTMLInputElement>('ytd-login-email').value.trim();
+        const password = $<HTMLInputElement>('ytd-login-password').value;
         const errEl = $('ytd-login-error');
         errEl.textContent = '';
         const res = await fetch('/api/admin/login', {
@@ -426,17 +503,25 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ email, password }),
         });
-        let data; try { data = await res.json(); } catch (e) { data = {}; }
-        if (!res.ok) { errEl.textContent = data.error || 'Login failed.'; return; }
+        let data: AdminLoginResponse;
+        try {
+            data = (await res.json()) as AdminLoginResponse;
+        } catch {
+            data = {};
+        }
+        if (!res.ok) {
+            errEl.textContent = data.error || 'Login failed.';
+            return;
+        }
         isAdmin = true;
-        applyAdminUI(data.email);
+        applyAdminUI(data.email ?? null);
         closeModal('ytd-login-modal');
-        $('ytd-login-password').value = '';
+        $<HTMLInputElement>('ytd-login-password').value = '';
         await loadBattles();
         await loadDancers();
     }
 
-    async function logout() {
+    async function logout(): Promise<void> {
         await fetch('/api/admin/logout', { method: 'POST' });
         isAdmin = false;
         applyAdminUI(null);
@@ -444,8 +529,8 @@
 
     // ---- entry ----
 
-    // Called by the router (js/router.js) after it activates the stats screen.
-    async function enterStats() {
+    // Called by the router (js/router.ts) after it activates the stats screen.
+    async function enterStats(): Promise<void> {
         await refreshAdmin();
         await loadYears();
         await loadStandings();
@@ -454,21 +539,33 @@
     }
     window.ytdOnEnterStats = enterStats;
 
-    function escapeHtml(s) {
+    function escapeHtml(s: unknown): string {
         return String(s == null ? '' : s)
-            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
     }
 
     document.addEventListener('DOMContentLoaded', () => {
-        const on = (id, evt, fn) => { const el = $(id); if (el) el.addEventListener(evt, fn); };
+        const on = (id: string, evt: string, fn: (e: Event) => void) => {
+            const el = $(id);
+            if (el) el.addEventListener(evt, fn);
+        };
 
-        on('go-to-ytd', 'click', () => window.navigate('/stats'));
-        on('ytd-back-home', 'click', () => window.navigate('/'));
-        on('ytd-year-select', 'change', async () => { await loadStandings(); await loadBattles(); });
+        on('go-to-ytd', 'click', () => window.navigate!('/stats'));
+        on('ytd-back-home', 'click', () => window.navigate!('/'));
+        on('ytd-year-select', 'change', async () => {
+            await loadStandings();
+            await loadBattles();
+        });
 
         // admin login modal
-        on('ytd-admin-login-btn', 'click', () => { $('ytd-login-error').textContent = ''; openModal('ytd-login-modal'); });
+        on('ytd-admin-login-btn', 'click', () => {
+            $('ytd-login-error').textContent = '';
+            openModal('ytd-login-modal');
+        });
         on('ytd-login-cancel', 'click', () => closeModal('ytd-login-modal'));
         on('ytd-login-submit', 'click', submitLogin);
         on('ytd-admin-logout-btn', 'click', logout);
@@ -485,12 +582,14 @@
         on('ytd-merge-selected-btn', 'click', openMergeModal);
         on('ytd-merge-cancel', 'click', () => closeModal('ytd-merge-modal'));
         on('ytd-merge-confirm', 'click', confirmMerge);
-        on('ytd-merge-name', 'input', () => { mergeNameDirty = true; });
+        on('ytd-merge-name', 'input', () => {
+            mergeNameDirty = true;
+        });
 
         // file name display
         on('ytd-file-input', 'change', () => {
-            const f = $('ytd-file-input').files[0];
-            $('ytd-file-name').textContent = f ? f.name : '';
+            const files = $<HTMLInputElement>('ytd-file-input').files;
+            $('ytd-file-name').textContent = files && files[0] ? files[0].name : '';
         });
 
         // reflect admin state on the results screen's publish button on first load


### PR DESCRIPTION
Stacked on #73 (Phase 5 tooling) — merge that first. First conversion slice of the TypeScript migration.

## What's here

- **`web/js/types.ts`** — the API payload contract in one place: YTD stats/admin shapes, the `hustlentussle.battle` v1 export format (mirroring `build_battle_export`/`parse_battle_json` in `web/helpers.py`), `/api/state` and `/api/results` shapes. Types only — consumed via `import type`, which esbuild erases, so the build stays transform-only (still no bundling; that flip comes when real imports appear).
- **`web/js/global.d.ts`** — the cross-file window surface (~12 symbols: `navigate`, `showScreen`, `ytdOnEnterStats`, `DebugTools`, …). app.js's ~90 internal globals deliberately excluded — they become module-scoped as files convert.
- **`router.js` → `router.ts`** (strict). Cross-file calls now go through `window.*` explicitly. Zero app.js changes needed: top-level `function` declarations in classic scripts already exist as window properties.
- **`ytd.js` → `ytd.ts`** (strict, fully typed against types.ts). Dropped the unused `showScreenById` helper; behavior otherwise identical.
- **`scripts/smoke_ui.py`** — the Phase 7 deliverable pulled forward as the gate for every conversion PR: Playwright drives setup → start battle → vote/submit ×2 → undo → re-vote → end-early → results → stats through the real UI, failing on any JS page/console error. (Votes target a fixed dancer per role so end-early resolves without a tie-break — found that the hard way.)

## Verification

- `npm run build` / `typecheck` (strict) / `lint` all green; emitted `dist/ytd.js` confirmed to be a plain classic script with the type import stripped.
- **UI smoke passes end-to-end** against the dev server on the converted code — 9 steps, zero JS errors. dev.hustlentussle.com is serving this branch now.

## Remaining Phase 6 slices (next PRs)

6b: `explainers.ts` + `DebugTools.ts` → 6c: `api.ts` typed fetch layer + bundle flip → 6d+: carve app.js by seam (spotify/demo/display/results/tiebreak/voting) → final `app.ts` strict + single entry. Then re-enable `--minify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzXaPTBzzSBBd8SZTqmCSM