### PR TITLE
Add Instagram post exports for YTD stats + battles, and dancer rename

### DIFF
--- a/stats/stats_repository.py
+++ b/stats/stats_repository.py
@@ -124,6 +124,39 @@ class StatsRepository:
             (alias, dancer_id, alias, alias),
         )
 
+    def rename_dancer(self, dancer_id: str, new_display_name: str) -> bool:
+        """Change a single dancer's canonical display name (no merge involved).
+
+        The old name is preserved as an alias, same as the rename-on-merge path in
+        merge_dancers, so a future upload spelled with the old name still resolves
+        to this dancer. Returns False if the dancer doesn't exist.
+        """
+        new_name = (new_display_name or "").strip()
+        if not new_name:
+            raise StatsError("Display name is required.")
+
+        with self._connection() as conn:
+            try:
+                with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                    cur.execute("SELECT display_name FROM dancers WHERE id = %s", (dancer_id,))
+                    row = cur.fetchone()
+                    if not row:
+                        return False
+                    old_name = row["display_name"]
+                    if new_name.lower() == old_name.strip().lower():
+                        return True
+
+                    cur.execute("UPDATE dancers SET display_name = %s WHERE id = %s", (new_name, dancer_id))
+                    self._maybe_add_alias(cur, dancer_id, old_name)
+                conn.commit()
+                return True
+            except psycopg2.errors.UniqueViolation as exc:
+                conn.rollback()
+                raise DuplicateDancerError("Another dancer already has that name.") from exc
+            except Exception as exc:  # noqa: BLE001
+                conn.rollback()
+                raise StatsError(str(exc)) from exc
+
     def merge_dancers(
         self,
         target_id: str,

--- a/web/index.html
+++ b/web/index.html
@@ -694,7 +694,7 @@
                 <button id="back-to-home-from-results" class="btn primary">Back to Home</button>
                 <button id="edit-results-btn" class="btn secondary" style="display:none;">Edit Results</button>
                 <button id="download-battle-data" class="btn secondary">Download Battle Data (JSON)</button>
-                <button id="export-social-image" class="btn secondary">Share Results (9:16)</button>
+                <button id="export-social-image" class="btn secondary">Share Results (Instagram Post)</button>
                 <button id="publish-to-ytd" class="btn secondary" style="display:none;">Publish to Year-to-Date Stats</button>
             </div>
         </div>
@@ -785,6 +785,7 @@
             <div class="ytd-controls">
                 <label for="ytd-year-select">Year</label>
                 <select id="ytd-year-select"></select>
+                <button id="ytd-export-image-btn" class="btn secondary small">Export Top 8 (Instagram Post)</button>
             </div>
 
             <div class="leaderboard">
@@ -833,7 +834,7 @@
                     <summary class="ytd-collapsible-summary"><h4>Edit Dancers</h4></summary>
                     <p class="note">Select two or more of the same person (e.g. a typo'd name left behind after an edit) and merge them into one identity.</p>
                     <table class="results-table">
-                        <thead><tr><th></th><th>Name</th><th>Aliases</th><th>Battles</th></tr></thead>
+                        <thead><tr><th></th><th>Name</th><th>Aliases</th><th>Battles</th><th></th></tr></thead>
                         <tbody id="ytd-dancers-body"></tbody>
                     </table>
                     <button id="ytd-merge-selected-btn" class="btn secondary small" disabled>Merge Selected</button>

--- a/web/js/global.d.ts
+++ b/web/js/global.d.ts
@@ -49,6 +49,10 @@ declare global {
                 ) => Promise<void>;
             },
         ) => void;
+        exportBattleResultsImage?: (
+            payload: BattleExportV1,
+            meta: { name: string; battle_date: string },
+        ) => Promise<void>;
         sessionId?: string | null;
 
         // ytd.ts

--- a/web/js/results.ts
+++ b/web/js/results.ts
@@ -11,7 +11,8 @@
 
 import { getResults } from './api';
 import { stopDisplayPolling } from './display';
-import { downloadCanvasAsPng, getSocialTheme, isDarkTheme, roundRect, slugify, SOCIAL_H, SOCIAL_W } from './socialImage';
+import { downloadCanvasAsPng, fitNameToBox, getSocialTheme, isDarkTheme, roundRect, singleLineBaseline, slugify, SOCIAL_H, SOCIAL_W } from './socialImage';
+import type { FitNameResult } from './socialImage';
 import { getSpotifyToken, isSpotifyEnabled } from './spotify';
 import { showToast } from './toast';
 import type {
@@ -1077,17 +1078,70 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
 
     // rowH fills all available vertical space; badgeSize is the smaller of the two constraints
     const maxRowHFromSpace = maxDancers > 0 ? Math.floor(availForRows / (2 * maxDancers)) : 70;
-    const rowH = Math.max(36, maxRowHFromSpace);
-    const badgeSize = Math.max(16, Math.min(rowH - 18, badgeSizeFromRounds));
-    const bFontSize = Math.max(9, Math.round(badgeSize * 0.52));
-    const nameFontSize = Math.max(20, Math.min(44, rowH - 26));
-    const rankFontSize = Math.max(16, nameFontSize - 4);
+    let rowH = Math.max(36, maxRowHFromSpace);
+    let badgeSize = Math.max(16, Math.min(rowH - 18, badgeSizeFromRounds));
+    let bFontSize = Math.max(9, Math.round(badgeSize * 0.52));
+    let nameFontSize = Math.max(20, Math.min(44, rowH - 26));
+    let rankFontSize = Math.max(16, nameFontSize - 4);
+    let minNameFontSize = Math.max(16, Math.round(nameFontSize * 0.7));
 
-    const drawSection = (order: string[], map: Map<string, RoundBadge[]>, topName: string | null, label: string, startY: number): number => {
+    // A name that doesn't fit on one line even after shrinking wraps onto two lines instead
+    // of being cut short (see fitNameToBox in socialImage.ts). A wrapped row needs more
+    // vertical room than a normal row; WRAP_ROWS is how much more.
+    const WRAP_ROWS = 1.7;
+
+    interface PlannedRow {
+        fit: FitNameResult;
+        isTop: boolean;
+        height: number;
+    }
+    interface SectionPlan {
+        rows: PlannedRow[];
+        totalHeight: number;
+    }
+
+    const planSection = (order: string[], topName: string | null): SectionPlan => {
+        let totalHeight = 0;
+        const rows = order.map(name => {
+            const isTop = name === topName;
+            const fit = fitNameToBox(ctx, name, nameAreaW, nameFontSize, minNameFontSize, C.fontBody, isTop);
+            const height = fit.lines.length === 2 ? rowH * WRAP_ROWS : rowH;
+            totalHeight += height;
+            return { fit, isTop, height };
+        });
+        return { rows, totalHeight };
+    };
+
+    let leadsPlan = planSection(leadsOrder, topLeadName);
+    let followsPlan = planSection(followsOrder, topFollowName);
+    const wrapCount = [...leadsPlan.rows, ...followsPlan.rows].filter(r => r.fit.lines.length === 2).length;
+
+    if (wrapCount > 0) {
+        // Give wrapped rows their extra room by shrinking the shared rowH, then re-derive
+        // everything sized off it (and re-run the fit so its own results match what's drawn).
+        const effectiveUnits = 2 * maxDancers + wrapCount * (WRAP_ROWS - 1);
+        rowH = Math.max(36, Math.floor(availForRows / effectiveUnits));
+        badgeSize = Math.max(16, Math.min(rowH - 18, badgeSizeFromRounds));
+        bFontSize = Math.max(9, Math.round(badgeSize * 0.52));
+        nameFontSize = Math.max(20, Math.min(44, rowH - 26));
+        rankFontSize = Math.max(16, nameFontSize - 4);
+        minNameFontSize = Math.max(16, Math.round(nameFontSize * 0.7));
+
+        leadsPlan = planSection(leadsOrder, topLeadName);
+        followsPlan = planSection(followsOrder, topFollowName);
+    }
+
+    const drawSection = (
+        order: string[],
+        map: Map<string, RoundBadge[]>,
+        label: string,
+        startY: number,
+        plan: SectionPlan,
+    ): number => {
         const CARD_RADIUS = 20;
         const cardX = PAD - 12;
         const cardW = W - 2 * (PAD - 12);
-        const cardH = CARD_HEADER_H + order.length * rowH + CARD_PAD_BOTTOM;
+        const cardH = CARD_HEADER_H + plan.totalHeight + CARD_PAD_BOTTOM;
 
         // Card background
         roundRect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
@@ -1115,46 +1169,58 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
         ctx.fillText(label.toUpperCase(), cardX + 24, startY + CARD_HEADER_H - 18);
 
         const rowsStartY = startY + CARD_HEADER_H;
+        let rowY = rowsStartY;
 
         order.forEach((name, idx) => {
-            const rowY = rowsStartY + idx * rowH;
-            const isTop = name === topName;
-            const textBaseY = rowY + rowH * 0.64;
+            const { fit, isTop, height: rowHeight } = plan.rows[idx];
+            const isWrapped = fit.lines.length === 2;
 
             // Alternating row tint
             if (idx % 2 === 0) {
                 ctx.fillStyle = C.rowAlt;
-                ctx.fillRect(PAD - 8, rowY + 1, W - (PAD - 8) * 2, rowH - 1);
+                ctx.fillRect(PAD - 8, rowY + 1, W - (PAD - 8) * 2, rowHeight - 1);
             }
 
-            // Rank
+            // Rank — same baseline formula as a normal row; centered instead for a wrapped row,
+            // whose height doesn't match what that formula was tuned for.
+            const rankBaseY = singleLineBaseline(rowY, rowHeight, rankFontSize, isWrapped);
             ctx.fillStyle = C.textMuted;
             ctx.font = `400 ${rankFontSize}px ${C.fontMono}`;
             ctx.textAlign = 'left';
-            ctx.fillText((idx + 1) + '.', PAD, textBaseY);
+            ctx.fillText((idx + 1) + '.', PAD, rankBaseY);
 
-            // Name + crown — clipped to nameAreaW so crown never bleeds into badge area
+            // Name (1 or 2 lines, per fitNameToBox) + crown — clipped to the row's full height
+            // so a wrapped second line (or a bleeding crown) never spills into the badge area.
             ctx.save();
             ctx.beginPath();
-            ctx.rect(PAD + rankW, rowY, nameAreaW, rowH);
+            ctx.rect(PAD + rankW, rowY, nameAreaW, rowHeight);
             ctx.clip();
-            const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
-            const displayName = name.length > maxChars ? name.slice(0, maxChars - 1) + '…' : name;
             ctx.fillStyle = isTop ? C.textPrimary : C.textSecondary;
             ctx.font = isTop
-                ? `bold ${nameFontSize}px ${C.fontBody}`
-                : `400 ${nameFontSize}px ${C.fontBody}`;
-            ctx.fillText(displayName, PAD + rankW, textBaseY);
+                ? `bold ${fit.fontSize}px ${C.fontBody}`
+                : `400 ${fit.fontSize}px ${C.fontBody}`;
+
+            let lastLineY: number;
+            if (!isWrapped) {
+                lastLineY = rowY + rowHeight * 0.64;
+                ctx.fillText(fit.lines[0], PAD + rankW, lastLineY);
+            } else {
+                const lineGap = fit.fontSize * 1.15;
+                const line1Y = rowY + rowHeight / 2 - lineGap / 2 + fit.fontSize * 0.35;
+                lastLineY = line1Y + lineGap;
+                ctx.fillText(fit.lines[0], PAD + rankW, line1Y);
+                ctx.fillText(fit.lines[1], PAD + rankW, lastLineY);
+            }
             if (isTop) {
-                const nameW2 = ctx.measureText(displayName).width;
-                ctx.font = `${nameFontSize}px serif`;
-                ctx.fillText('👑', PAD + rankW + nameW2 + 5, textBaseY);
+                const lastLineW = ctx.measureText(fit.lines[fit.lines.length - 1]).width;
+                ctx.font = `${fit.fontSize}px serif`;
+                ctx.fillText('👑', PAD + rankW + lastLineW + 5, lastLineY);
             }
             ctx.restore();
 
-            // Round badges — one row of circles
+            // Round badges — one row of circles, vertically centered on the row's actual height
             const rounds = (map.get(name) || []).slice().sort((a, b) => a.round - b.round);
-            const badgeCY = rowY + rowH / 2;
+            const badgeCY = rowY + rowHeight / 2;
             rounds.forEach((info, bi) => {
                 const cx = badgeStartX + bi * (badgeSize + badgeGap) + badgeSize / 2;
                 const cy = badgeCY;
@@ -1176,13 +1242,15 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
                 ctx.textAlign = 'center';
                 ctx.fillText(String(info.round), cx, cy + bFontSize * 0.37);
             });
+
+            rowY += rowHeight;
         });
 
-        return rowsStartY + order.length * rowH + CARD_PAD_BOTTOM;
+        return rowsStartY + plan.totalHeight + CARD_PAD_BOTTOM;
     };
 
-    const leadsEnd = drawSection(leadsOrder, leadMap, topLeadName, 'Leads', contentStartY);
-    drawSection(followsOrder, followMap, topFollowName, 'Follows', leadsEnd + SECTION_GAP);
+    const leadsEnd = drawSection(leadsOrder, leadMap, 'Leads', contentStartY, leadsPlan);
+    drawSection(followsOrder, followMap, 'Follows', leadsEnd + SECTION_GAP, followsPlan);
 
     return canvas;
 }

--- a/web/js/results.ts
+++ b/web/js/results.ts
@@ -11,9 +11,19 @@
 
 import { getResults } from './api';
 import { stopDisplayPolling } from './display';
+import { downloadCanvasAsPng, getSocialTheme, isDarkTheme, roundRect, slugify, SOCIAL_H, SOCIAL_W } from './socialImage';
 import { getSpotifyToken, isSpotifyEnabled } from './spotify';
 import { showToast } from './toast';
-import type { BattleExportV1, ExportRound, ResultRow, ResultsResponse, ResultsRound, ScoreboardRow } from './types';
+import type {
+    BattleExportV1,
+    ExportParticipant,
+    ExportRound,
+    ResultRow,
+    ResultsResponse,
+    ResultsRound,
+    RoundPairs,
+    ScoreboardRow,
+} from './types';
 
 export type ResultsData = ResultsResponse & { uploaded?: boolean };
 
@@ -70,6 +80,45 @@ let resultsTopLeadName: string | null = null;
 let resultsTopFollowName: string | null = null;
 let resultsGuestJudges: string[] = [];
 const resultsEventTitle: string | null = null; // custom subtitle; falls back to "Month Edition (Year)"
+
+/** Minimal round shape shared by ResultsRound and ExportRound (rounds/raw-payload interchangeably). */
+interface RoundLike {
+    round_num: number;
+    pairs: RoundPairs | null;
+    lead_winner: string | null;
+    follow_winner: string | null;
+    tiebreak?: boolean;
+    tiebreak_leads?: string[];
+    tiebreak_follows?: string[];
+}
+
+/** Builds per-dancer round win/loss badge maps from a battle's rounds — used both for the
+ * currently-displayed results screen and for a raw stored battle payload (social image export). */
+function buildRoundMaps(rounds: RoundLike[]): { leadMap: Map<string, RoundBadge[]>; followMap: Map<string, RoundBadge[]> } {
+    const leadMap = new Map<string, RoundBadge[]>();
+    const followMap = new Map<string, RoundBadge[]>();
+    rounds.forEach(r => {
+        const roundNum = r.round_num;
+        const push = (map: Map<string, RoundBadge[]>, name: string, win: boolean): void => {
+            if (!map.has(name)) map.set(name, []);
+            map.get(name)?.push({ round: roundNum, win });
+        };
+        if (r.tiebreak) {
+            (r.tiebreak_leads || []).forEach(name => push(leadMap, name, r.lead_winner === name));
+            (r.tiebreak_follows || []).forEach(name => push(followMap, name, r.follow_winner === name));
+            return;
+        }
+        const pair1Lead = r.pairs?.pair_1?.lead;
+        const pair1Follow = r.pairs?.pair_1?.follow;
+        const pair2Lead = r.pairs?.pair_2?.lead;
+        const pair2Follow = r.pairs?.pair_2?.follow;
+        if (pair1Lead) push(leadMap, pair1Lead, r.lead_winner === pair1Lead);
+        if (pair2Lead) push(leadMap, pair2Lead, r.lead_winner === pair2Lead);
+        if (pair1Follow) push(followMap, pair1Follow, r.follow_winner === pair1Follow);
+        if (pair2Follow) push(followMap, pair2Follow, r.follow_winner === pair2Follow);
+    });
+    return { leadMap, followMap };
+}
 
 export function setUploadedBattlePayload(payload: BattleExportV1 | null): void {
     uploadedBattlePayload = payload;
@@ -204,28 +253,7 @@ export async function displayResults(data: ResultsData): Promise<void> {
 
     // Build battle graphic data: map contestant to rounds and wins
     if (Array.isArray(data.rounds) && data.rounds.length > 0 && leadGraphic && followGraphic) {
-        const leadMap = new Map<string, RoundBadge[]>();
-        const followMap = new Map<string, RoundBadge[]>();
-        data.rounds.forEach(r => {
-            const roundNum = r.round_num;
-            const push = (map: Map<string, RoundBadge[]>, name: string, win: boolean): void => {
-                if (!map.has(name)) map.set(name, []);
-                map.get(name)?.push({ round: roundNum, win });
-            };
-            if (r.tiebreak) {
-                (r.tiebreak_leads || []).forEach(name => push(leadMap, name, r.lead_winner === name));
-                (r.tiebreak_follows || []).forEach(name => push(followMap, name, r.follow_winner === name));
-                return;
-            }
-            const pair1Lead = r.pairs?.pair_1?.lead;
-            const pair1Follow = r.pairs?.pair_1?.follow;
-            const pair2Lead = r.pairs?.pair_2?.lead;
-            const pair2Follow = r.pairs?.pair_2?.follow;
-            if (pair1Lead) push(leadMap, pair1Lead, r.lead_winner === pair1Lead);
-            if (pair2Lead) push(leadMap, pair2Lead, r.lead_winner === pair2Lead);
-            if (pair1Follow) push(followMap, pair1Follow, r.follow_winner === pair1Follow);
-            if (pair2Follow) push(followMap, pair2Follow, r.follow_winner === pair2Follow);
-        });
+        const { leadMap, followMap } = buildRoundMaps(data.rounds);
 
         // Helper to render a column by initial order
         const renderGraphicColumn = (initialOrder: string[], dataMap: Map<string, RoundBadge[]>, topName: string | null, container: HTMLElement): void => {
@@ -964,77 +992,35 @@ async function saveEditedResults(): Promise<void> {
     }
 }
 
-// ---- Social image export ----
+// ---- Social image export (Instagram feed post, 4:5) ----
 
-function _rrect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
-    ctx.beginPath();
-    ctx.moveTo(x + r, y);
-    ctx.lineTo(x + w - r, y);
-    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
-    ctx.lineTo(x + w, y + h - r);
-    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-    ctx.lineTo(x + r, y + h);
-    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
-    ctx.lineTo(x, y + r);
-    ctx.quadraticCurveTo(x, y, x + r, y);
-    ctx.closePath();
+interface BattleImageParams {
+    leadsOrder: string[];
+    followsOrder: string[];
+    leadMap: Map<string, RoundBadge[]>;
+    followMap: Map<string, RoundBadge[]>;
+    topLeadName: string | null;
+    topFollowName: string | null;
+    guestJudges: string[];
+    subtitleText: string;
 }
 
-async function exportSocialImage(): Promise<void> {
-    const W = 1080;
-    const H = 1920;
+/** Draws the battle-results social image (header + Leads/Follows cards with round badges)
+ * onto a fresh off-DOM canvas. Shared by the live/uploaded results screen export and the
+ * admin per-battle export (driven from a stored battle's raw payload). */
+function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement | null {
+    const { leadsOrder, followsOrder, leadMap, followMap, topLeadName, topFollowName, guestJudges, subtitleText } = params;
+    const W = SOCIAL_W;
+    const H = SOCIAL_H;
     const PAD = 50;
 
-    await document.fonts.ready;
-
-    // Mirror the app's current light/dark theme
-    const isDark = document.documentElement.getAttribute('data-color') === 'dark';
-    const C = isDark ? {
-        bg:            '#0a0a12',
-        bgCard:        '#1a1a2e',
-        accent:        '#7c3aed',
-        textPrimary:   '#f1f5f9',
-        textSecondary: '#94a3b8',
-        textMuted:     '#64748b',
-        border:        'rgba(148,163,184,0.12)',
-        rowAlt:        'rgba(255,255,255,0.03)',
-        badgeWin:      '#7c3aed',
-        badgeWinBorder:'#9d5cf5',
-        badgeLose:     'rgba(255,255,255,0.07)',
-        badgeLoseBorder:'rgba(148,163,184,0.15)',
-        badgeWinText:  '#ffffff',
-        badgeLoseText: '#64748b',
-        fontDisplay:   '"Space Grotesk","Inter",sans-serif',
-        fontBody:      '"Inter","DM Sans",sans-serif',
-        fontMono:      '"DM Mono",monospace',
-    } : {
-        bg:            '#f5f5f7',
-        bgCard:        '#ffffff',
-        accent:        '#1d4ed8',
-        textPrimary:   '#0f172a',
-        textSecondary: '#475569',
-        textMuted:     '#94a3b8',
-        border:        '#e2e8f0',
-        rowAlt:        'rgba(0,0,0,0.03)',
-        badgeWin:      '#1d4ed8',
-        badgeWinBorder:'#1e40af',
-        badgeLose:     '#f0f0f5',
-        badgeLoseBorder:'#e2e8f0',
-        badgeWinText:  '#ffffff',
-        badgeLoseText: '#94a3b8',
-        fontDisplay:   '"DM Sans",sans-serif',
-        fontBody:      '"DM Sans",sans-serif',
-        fontMono:      '"DM Mono",monospace',
-    };
+    const C = getSocialTheme(isDarkTheme());
 
     const canvas = document.createElement('canvas');
     canvas.width = W;
     canvas.height = H;
     const ctx = canvas.getContext('2d');
-    if (!ctx) {
-        showToast('Failed to generate image', 'error');
-        return;
-    }
+    if (!ctx) return null;
 
     // Background
     ctx.fillStyle = C.bg;
@@ -1050,29 +1036,18 @@ async function exportSocialImage(): Promise<void> {
     ctx.font = `bold 78px ${C.fontDisplay}`;
     ctx.fillText("Hustle n' Tussle", W / 2, 130);
 
-    const now = new Date();
-    const subtitleText = resultsEventTitle
-        || `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
     ctx.fillStyle = C.textSecondary;
     ctx.font = `400 38px ${C.fontBody}`;
     ctx.fillText(subtitleText, W / 2, 200);
 
-    if (resultsGuestJudges.length > 0) {
-        const judgeLabel = resultsGuestJudges.length === 1 ? 'Judge' : 'Judges';
+    if (guestJudges.length > 0) {
+        const judgeLabel = guestJudges.length === 1 ? 'Judge' : 'Judges';
         ctx.fillStyle = C.textSecondary;
         ctx.font = `600 40px ${C.fontDisplay}`;
-        ctx.fillText(`${judgeLabel}: ${resultsGuestJudges.join(', ')}`, W / 2, 258);
+        ctx.fillText(`${judgeLabel}: ${guestJudges.join(', ')}`, W / 2, 258);
     }
 
-    const scoreboard = deps?.getScoreboard() || { leads: [], follows: [] };
-    const sortedLeads = [...scoreboard.leads].sort((a, b) => (b.points || 0) - (a.points || 0));
-    const sortedFollows = [...scoreboard.follows].sort((a, b) => (b.points || 0) - (a.points || 0));
-
     const contentStartY = 300;
-
-    // --- Battle Graphic ---
-    const leadsOrder = resultsInitialLeads.length ? resultsInitialLeads : sortedLeads.map(l => l.name);
-    const followsOrder = resultsInitialFollows.length ? resultsInitialFollows : sortedFollows.map(f => f.name);
 
     // Layout: two card sections (Leads then Follows)
     const CARD_HEADER_H = 76;   // dark strip at top of each card
@@ -1094,8 +1069,8 @@ async function exportSocialImage(): Promise<void> {
     // Use the most rounds any individual dancer competed in (not total game rounds)
     // so the badge row fills the full width for the most active dancer.
     const allRoundCounts = [
-        ...[...leadsOrder].map(n => (resultsLeadMap.get(n) || []).length),
-        ...[...followsOrder].map(n => (resultsFollowMap.get(n) || []).length),
+        ...leadsOrder.map(n => (leadMap.get(n) || []).length),
+        ...followsOrder.map(n => (followMap.get(n) || []).length),
     ];
     const maxRoundsPerDancer = Math.max(...allRoundCounts, 1);
     const badgeSizeFromRounds = Math.floor((badgeAreaW + badgeGap) / maxRoundsPerDancer) - badgeGap;
@@ -1115,20 +1090,20 @@ async function exportSocialImage(): Promise<void> {
         const cardH = CARD_HEADER_H + order.length * rowH + CARD_PAD_BOTTOM;
 
         // Card background
-        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        roundRect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
         ctx.fillStyle = C.bgCard;
         ctx.fill();
 
         // Accent header strip — clipped to card shape so top corners are rounded
         ctx.save();
-        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        roundRect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
         ctx.clip();
         ctx.fillStyle = C.accent;
         ctx.fillRect(cardX, startY, cardW, CARD_HEADER_H);
         ctx.restore();
 
         // Card border
-        _rrect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        roundRect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
         ctx.strokeStyle = C.border;
         ctx.lineWidth = 1.5;
         ctx.stroke();
@@ -1206,21 +1181,79 @@ async function exportSocialImage(): Promise<void> {
         return rowsStartY + order.length * rowH + CARD_PAD_BOTTOM;
     };
 
-    const leadsEnd = drawSection(leadsOrder, resultsLeadMap, resultsTopLeadName, 'Leads', contentStartY);
-    drawSection(followsOrder, resultsFollowMap, resultsTopFollowName, 'Follows', leadsEnd + SECTION_GAP);
+    const leadsEnd = drawSection(leadsOrder, leadMap, topLeadName, 'Leads', contentStartY);
+    drawSection(followsOrder, followMap, topFollowName, 'Follows', leadsEnd + SECTION_GAP);
 
-    canvas.toBlob(blob => {
-        if (!blob) { showToast('Failed to generate image', 'error'); return; }
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'hnt-results.png';
-        document.body.appendChild(a);
-        a.click();
-        URL.revokeObjectURL(url);
-        document.body.removeChild(a);
-    }, 'image/png');
+    return canvas;
 }
+
+async function exportSocialImage(): Promise<void> {
+    await document.fonts.ready;
+
+    const scoreboard = deps?.getScoreboard() || { leads: [], follows: [] };
+    const sortedLeads = [...scoreboard.leads].sort((a, b) => (b.points || 0) - (a.points || 0));
+    const sortedFollows = [...scoreboard.follows].sort((a, b) => (b.points || 0) - (a.points || 0));
+
+    const leadsOrder = resultsInitialLeads.length ? resultsInitialLeads : sortedLeads.map(l => l.name);
+    const followsOrder = resultsInitialFollows.length ? resultsInitialFollows : sortedFollows.map(f => f.name);
+
+    const now = new Date();
+    const subtitleText = resultsEventTitle
+        || `${now.toLocaleDateString('en-US', { month: 'long' })} Edition (${now.getFullYear()})`;
+
+    const canvas = renderBattleResultsCanvas({
+        leadsOrder,
+        followsOrder,
+        leadMap: resultsLeadMap,
+        followMap: resultsFollowMap,
+        topLeadName: resultsTopLeadName,
+        topFollowName: resultsTopFollowName,
+        guestJudges: resultsGuestJudges,
+        subtitleText,
+    });
+    if (!canvas) {
+        showToast('Failed to generate image', 'error');
+        return;
+    }
+    downloadCanvasAsPng(canvas, 'hnt-results.png', () => showToast('Failed to generate image', 'error'));
+}
+
+/** Order a battle's participants by their initial (pre-battle) queue order, falling back to
+ * points-desc when initial_order wasn't recorded (e.g. an older export). */
+function orderParticipants(list: ExportParticipant[]): string[] {
+    const hasOrder = list.length > 0 && list.every(p => p.initial_order !== null && p.initial_order !== undefined);
+    const sorted = hasOrder
+        ? [...list].sort((a, b) => (a.initial_order as number) - (b.initial_order as number))
+        : [...list].sort((a, b) => (b.points || 0) - (a.points || 0));
+    return sorted.map(p => p.name);
+}
+
+/** Generates the same battle-results social image for a stored battle payload (not the
+ * currently-displayed results screen) — used by the YTD admin "Instagram Post" button. */
+async function exportBattleImageFromPayload(payload: BattleExportV1, meta: { name: string; battle_date: string }): Promise<void> {
+    await document.fonts.ready;
+
+    const leadsOrder = orderParticipants(payload.participants?.leads || []);
+    const followsOrder = orderParticipants(payload.participants?.follows || []);
+    const { leadMap, followMap } = buildRoundMaps(payload.rounds || []);
+
+    const canvas = renderBattleResultsCanvas({
+        leadsOrder,
+        followsOrder,
+        leadMap,
+        followMap,
+        topLeadName: payload.champions?.lead?.name ?? null,
+        topFollowName: payload.champions?.follow?.name ?? null,
+        guestJudges: payload.judges?.guest || [],
+        subtitleText: meta.name,
+    });
+    if (!canvas) {
+        showToast('Failed to generate image', 'error');
+        return;
+    }
+    downloadCanvasAsPng(canvas, `hnt-${slugify(meta.name)}-results.png`, () => showToast('Failed to generate image', 'error'));
+}
+window.exportBattleResultsImage = exportBattleImageFromPayload;
 
 // ---- Battle JSON download ----
 

--- a/web/js/socialImage.ts
+++ b/web/js/socialImage.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared canvas-drawing primitives for the "export as Instagram post" image
+ * features (battle results, per-battle admin export, YTD top-8). Kept
+ * dependency-free (no module state) so results.ts and ytd.ts can both
+ * `import` it directly.
+ */
+
+// Instagram feed-post ratio (4:5), the max vertical space Instagram allows
+// before cropping a feed post.
+export const SOCIAL_W = 1080;
+export const SOCIAL_H = 1350;
+
+export interface SocialTheme {
+    bg: string;
+    bgCard: string;
+    accent: string;
+    textPrimary: string;
+    textSecondary: string;
+    textMuted: string;
+    border: string;
+    rowAlt: string;
+    badgeWin: string;
+    badgeWinBorder: string;
+    badgeLose: string;
+    badgeLoseBorder: string;
+    badgeWinText: string;
+    badgeLoseText: string;
+    fontDisplay: string;
+    fontBody: string;
+    fontMono: string;
+}
+
+export function getSocialTheme(isDark: boolean): SocialTheme {
+    return isDark ? {
+        bg:            '#0a0a12',
+        bgCard:        '#1a1a2e',
+        accent:        '#7c3aed',
+        textPrimary:   '#f1f5f9',
+        textSecondary: '#94a3b8',
+        textMuted:     '#64748b',
+        border:        'rgba(148,163,184,0.12)',
+        rowAlt:        'rgba(255,255,255,0.03)',
+        badgeWin:      '#7c3aed',
+        badgeWinBorder:'#9d5cf5',
+        badgeLose:     'rgba(255,255,255,0.07)',
+        badgeLoseBorder:'rgba(148,163,184,0.15)',
+        badgeWinText:  '#ffffff',
+        badgeLoseText: '#64748b',
+        fontDisplay:   '"Space Grotesk","Inter",sans-serif',
+        fontBody:      '"Inter","DM Sans",sans-serif',
+        fontMono:      '"DM Mono",monospace',
+    } : {
+        bg:            '#f5f5f7',
+        bgCard:        '#ffffff',
+        accent:        '#1d4ed8',
+        textPrimary:   '#0f172a',
+        textSecondary: '#475569',
+        textMuted:     '#94a3b8',
+        border:        '#e2e8f0',
+        rowAlt:        'rgba(0,0,0,0.03)',
+        badgeWin:      '#1d4ed8',
+        badgeWinBorder:'#1e40af',
+        badgeLose:     '#f0f0f5',
+        badgeLoseBorder:'#e2e8f0',
+        badgeWinText:  '#ffffff',
+        badgeLoseText: '#94a3b8',
+        fontDisplay:   '"DM Sans",sans-serif',
+        fontBody:      '"DM Sans",sans-serif',
+        fontMono:      '"DM Mono",monospace',
+    };
+}
+
+export function isDarkTheme(): boolean {
+    return document.documentElement.getAttribute('data-color') === 'dark';
+}
+
+export function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+    ctx.lineTo(x + r, y + h);
+    ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+}
+
+export function downloadCanvasAsPng(canvas: HTMLCanvasElement, filename: string, onError?: () => void): void {
+    canvas.toBlob(blob => {
+        if (!blob) { onError?.(); return; }
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        URL.revokeObjectURL(url);
+        document.body.removeChild(a);
+    }, 'image/png');
+}
+
+/** lowercase, non-alphanumeric -> '-', trimmed; used for downloaded filenames. */
+export function slugify(s: string): string {
+    return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'battle';
+}

--- a/web/js/socialImage.ts
+++ b/web/js/socialImage.ts
@@ -102,7 +102,90 @@ export function downloadCanvasAsPng(canvas: HTMLCanvasElement, filename: string,
     }, 'image/png');
 }
 
+/**
+ * Baseline Y for a single line of text (rank number, points, etc.) vertically placed within
+ * a row. Normal (single-line-name) rows keep the original "0.64 down from the row top"
+ * placement rows have always used; a wrapped (two-line-name) row is taller than that formula
+ * was tuned for, so it centers the text on the row's actual height instead.
+ */
+export function singleLineBaseline(rowY: number, rowHeight: number, fontSize: number, isWrapped: boolean): number {
+    return isWrapped ? rowY + rowHeight / 2 + fontSize * 0.35 : rowY + rowHeight * 0.64;
+}
+
 /** lowercase, non-alphanumeric -> '-', trimmed; used for downloaded filenames. */
 export function slugify(s: string): string {
     return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'battle';
+}
+
+function fontString(size: number, family: string, bold: boolean): string {
+    return `${bold ? 'bold' : '400'} ${size}px ${family}`;
+}
+
+/** Shrinks `text` (via binary search on measured width) until it plus an ellipsis fits `maxWidth`.
+ * Assumes ctx.font is already set to the size/family the caller wants measured. */
+function truncateToWidth(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string {
+    if (ctx.measureText(text).width <= maxWidth) return text;
+    let lo = 0;
+    let hi = text.length;
+    while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (ctx.measureText(text.slice(0, mid) + '…').width <= maxWidth) lo = mid;
+        else hi = mid - 1;
+    }
+    return text.slice(0, lo) + '…';
+}
+
+export interface FitNameResult {
+    /** 1 or 2 lines to render, in order. */
+    lines: string[];
+    /** px size to use for every returned line. */
+    fontSize: number;
+}
+
+/**
+ * Fits a name into a box of `maxWidth`, in three tiers: shrink the font down to
+ * `minFontSize` to fit on one line; if a multi-word name still doesn't fit even at
+ * `minFontSize`, wrap it onto two lines; if it still doesn't fit (a single very long
+ * word, or an overflowing second line), truncate with an ellipsis as the last resort.
+ */
+export function fitNameToBox(
+    ctx: CanvasRenderingContext2D,
+    name: string,
+    maxWidth: number,
+    baseFontSize: number,
+    minFontSize: number,
+    fontFamily: string,
+    bold: boolean,
+): FitNameResult {
+    ctx.font = fontString(baseFontSize, fontFamily, bold);
+    if (ctx.measureText(name).width <= maxWidth) {
+        return { lines: [name], fontSize: baseFontSize };
+    }
+
+    const shrunk = Math.max(minFontSize, Math.min(baseFontSize - 1, Math.floor(baseFontSize * maxWidth / ctx.measureText(name).width)));
+    ctx.font = fontString(shrunk, fontFamily, bold);
+    if (ctx.measureText(name).width <= maxWidth) {
+        return { lines: [name], fontSize: shrunk };
+    }
+
+    // Doesn't fit on one line even at the size floor - wrap onto two lines if possible.
+    ctx.font = fontString(minFontSize, fontFamily, bold);
+    const words = name.trim().split(/\s+/);
+    if (words.length > 1) {
+        let line1 = words[0];
+        let i = 1;
+        for (; i < words.length; i++) {
+            const candidate = `${line1} ${words[i]}`;
+            if (ctx.measureText(candidate).width > maxWidth) break;
+            line1 = candidate;
+        }
+        const line2Raw = words.slice(i).join(' ');
+        if (line2Raw) {
+            if (ctx.measureText(line1).width > maxWidth) line1 = truncateToWidth(ctx, line1, maxWidth);
+            return { lines: [line1, truncateToWidth(ctx, line2Raw, maxWidth)], fontSize: minFontSize };
+        }
+    }
+
+    // Single unbreakable "word" (or wrapping produced no second line) - truncate as the last resort.
+    return { lines: [truncateToWidth(ctx, name, maxWidth)], fontSize: minFontSize };
 }

--- a/web/js/ytd.ts
+++ b/web/js/ytd.ts
@@ -164,7 +164,7 @@ import type {
         const pointsColX = cardX + cardW - 24;
         const nameFontSize = Math.max(20, Math.min(40, rowH - 26));
         const rankFontSize = Math.max(16, nameFontSize - 4);
-        const nameAreaW = cardW - 48 - rankW - 220;
+        const nameAreaW = cardW - 48 - rankW - 140;
 
         rows.forEach((row, idx) => {
             const rowY = rowsStartY + idx * rowH;
@@ -202,8 +202,7 @@ import type {
             ctx.textAlign = 'right';
             ctx.fillStyle = theme.textPrimary;
             ctx.font = `bold ${nameFontSize}px ${theme.fontMono}`;
-            const crownSuffix = row.crowns ? `  👑×${row.crowns}` : '';
-            ctx.fillText(`${row.total_points} pts${crownSuffix}`, pointsColX, textBaseY);
+            ctx.fillText(`${row.total_points} pts`, pointsColX, textBaseY);
         });
 
         return rowsStartY + rows.length * rowH + CARD_PAD_BOTTOM;

--- a/web/js/ytd.ts
+++ b/web/js/ytd.ts
@@ -3,6 +3,8 @@
  * Self-contained; reuses the existing `.screen`/`.active` show pattern and
  * shared button/table classes. Talks to /api/stats/* and /api/admin/* .
  */
+import { downloadCanvasAsPng, getSocialTheme, isDarkTheme, roundRect, SOCIAL_H, SOCIAL_W } from './socialImage';
+import { showToast } from './toast';
 import type {
     AdminLoginResponse,
     AdminMeResponse,
@@ -24,6 +26,7 @@ import type {
 
     let isAdmin = false;
     let preview: IngestPreviewResponse | null = null;
+    let currentStandings: Pick<YtdStandingsResponse, 'leads' | 'follows'> = { leads: [], follows: [] };
 
     // ---- screen helpers ----
 
@@ -92,6 +95,7 @@ import type {
             /* keep empty */
         }
 
+        currentStandings = data;
         renderStandings('ytd-lead-body', data.leads || []);
         renderStandings('ytd-follow-body', data.follows || []);
         const empty = (data.leads || []).length === 0 && (data.follows || []).length === 0;
@@ -111,6 +115,158 @@ import type {
                 `<td>${row.battles_entered || 0}</td>`;
             body.appendChild(tr);
         });
+    }
+
+    // ---- top-8 social image export (Instagram feed post, 4:5) ----
+
+    /** Draws one ranked "top 8" card (rank, name, points, crowns) — modeled on the
+     * battle-results card chrome in web/js/results.ts's drawSection(), but without
+     * round badges since YTD standings have no per-round data. */
+    function drawYtdCard(
+        ctx: CanvasRenderingContext2D,
+        theme: ReturnType<typeof getSocialTheme>,
+        rows: YtdStandingRow[],
+        label: string,
+        startY: number,
+        cardX: number,
+        cardW: number,
+        rowH: number,
+    ): number {
+        const CARD_HEADER_H = 76;
+        const CARD_PAD_BOTTOM = 16;
+        const CARD_RADIUS = 20;
+        const cardH = CARD_HEADER_H + rows.length * rowH + CARD_PAD_BOTTOM;
+
+        roundRect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.fillStyle = theme.bgCard;
+        ctx.fill();
+
+        ctx.save();
+        roundRect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.clip();
+        ctx.fillStyle = theme.accent;
+        ctx.fillRect(cardX, startY, cardW, CARD_HEADER_H);
+        ctx.restore();
+
+        roundRect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
+        ctx.strokeStyle = theme.border;
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+
+        ctx.fillStyle = '#ffffff';
+        ctx.font = `bold 52px ${theme.fontDisplay}`;
+        ctx.textAlign = 'left';
+        ctx.fillText(label.toUpperCase(), cardX + 24, startY + CARD_HEADER_H - 18);
+
+        const rowsStartY = startY + CARD_HEADER_H;
+        const rowPad = cardX + 24;
+        const rankW = 44;
+        const pointsColX = cardX + cardW - 24;
+        const nameFontSize = Math.max(20, Math.min(40, rowH - 26));
+        const rankFontSize = Math.max(16, nameFontSize - 4);
+        const nameAreaW = cardW - 48 - rankW - 220;
+
+        rows.forEach((row, idx) => {
+            const rowY = rowsStartY + idx * rowH;
+            const textBaseY = rowY + rowH * 0.64;
+            const isTop = idx === 0;
+
+            if (idx % 2 === 0) {
+                ctx.fillStyle = theme.rowAlt;
+                ctx.fillRect(cardX + 12, rowY + 1, cardW - 24, rowH - 1);
+            }
+
+            ctx.fillStyle = theme.textMuted;
+            ctx.font = `400 ${rankFontSize}px ${theme.fontMono}`;
+            ctx.textAlign = 'left';
+            ctx.fillText((idx + 1) + '.', rowPad, textBaseY);
+
+            ctx.save();
+            ctx.beginPath();
+            ctx.rect(rowPad + rankW, rowY, nameAreaW, rowH);
+            ctx.clip();
+            const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
+            const displayName = row.display_name.length > maxChars
+                ? row.display_name.slice(0, maxChars - 1) + '…'
+                : row.display_name;
+            ctx.fillStyle = isTop ? theme.textPrimary : theme.textSecondary;
+            ctx.font = isTop ? `bold ${nameFontSize}px ${theme.fontBody}` : `400 ${nameFontSize}px ${theme.fontBody}`;
+            ctx.fillText(displayName, rowPad + rankW, textBaseY);
+            if (isTop) {
+                const nameW = ctx.measureText(displayName).width;
+                ctx.font = `${nameFontSize}px serif`;
+                ctx.fillText('👑', rowPad + rankW + nameW + 5, textBaseY);
+            }
+            ctx.restore();
+
+            ctx.textAlign = 'right';
+            ctx.fillStyle = theme.textPrimary;
+            ctx.font = `bold ${nameFontSize}px ${theme.fontMono}`;
+            const crownSuffix = row.crowns ? `  👑×${row.crowns}` : '';
+            ctx.fillText(`${row.total_points} pts${crownSuffix}`, pointsColX, textBaseY);
+        });
+
+        return rowsStartY + rows.length * rowH + CARD_PAD_BOTTOM;
+    }
+
+    async function exportYtdImage(): Promise<void> {
+        const year = $<HTMLSelectElement>('ytd-year-select').value;
+        const top8Leads = (currentStandings.leads || []).slice(0, 8);
+        const top8Follows = (currentStandings.follows || []).slice(0, 8);
+        if (top8Leads.length === 0 && top8Follows.length === 0) {
+            showToast('No standings to export for this year.', 'error');
+            return;
+        }
+
+        await document.fonts.ready;
+
+        const W = SOCIAL_W;
+        const H = SOCIAL_H;
+        const PAD = 50;
+        const theme = getSocialTheme(isDarkTheme());
+
+        const canvas = document.createElement('canvas');
+        canvas.width = W;
+        canvas.height = H;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+            showToast('Failed to generate image', 'error');
+            return;
+        }
+
+        ctx.fillStyle = theme.bg;
+        ctx.fillRect(0, 0, W, H);
+
+        ctx.fillStyle = theme.accent;
+        ctx.fillRect(0, 0, W, 12);
+
+        ctx.textAlign = 'center';
+        ctx.fillStyle = theme.textPrimary;
+        ctx.font = `bold 78px ${theme.fontDisplay}`;
+        ctx.fillText("Hustle n' Tussle", W / 2, 130);
+
+        ctx.fillStyle = theme.textSecondary;
+        ctx.font = `400 38px ${theme.fontBody}`;
+        ctx.fillText(`Year-to-Date Stats — ${year}`, W / 2, 200);
+
+        const contentStartY = 260;
+        const CARD_HEADER_H = 76;
+        const CARD_PAD_BOTTOM = 16;
+        const SECTION_GAP = 20;
+        const FOOTER_H = 40;
+        const maxRows = Math.max(top8Leads.length, top8Follows.length, 1);
+        const availForRows = (H - FOOTER_H) - contentStartY
+            - 2 * (CARD_HEADER_H + CARD_PAD_BOTTOM)
+            - SECTION_GAP;
+        const rowH = Math.max(40, Math.floor(availForRows / (2 * maxRows)));
+
+        const cardX = PAD - 12;
+        const cardW = W - 2 * (PAD - 12);
+
+        const leadsEnd = drawYtdCard(ctx, theme, top8Leads, 'Leads', contentStartY, cardX, cardW, rowH);
+        drawYtdCard(ctx, theme, top8Follows, 'Follows', leadsEnd + SECTION_GAP, cardX, cardW, rowH);
+
+        downloadCanvasAsPng(canvas, `hnt-ytd-${year}-top8.png`, () => showToast('Failed to generate image', 'error'));
     }
 
     // ---- admin: contributed battles ----
@@ -140,6 +296,11 @@ import type {
             edit.textContent = 'Edit';
             edit.addEventListener('click', () => editBattle(b.id));
             actions.appendChild(edit);
+            const image = document.createElement('button');
+            image.className = 'btn secondary small';
+            image.textContent = 'Instagram Post';
+            image.addEventListener('click', () => exportBattleImage(b.id));
+            actions.appendChild(image);
             const del = document.createElement('button');
             del.className = 'btn secondary small';
             del.textContent = 'Delete';
@@ -148,6 +309,23 @@ import type {
             tr.appendChild(actions);
             body.appendChild(tr);
         });
+    }
+
+    async function exportBattleImage(id: string): Promise<void> {
+        let battle: BattleDetail;
+        try {
+            const res = await fetch(`/api/stats/battles/${id}`);
+            if (!res.ok) throw new Error();
+            battle = (await res.json()) as BattleDetail;
+        } catch {
+            alert('Failed to load battle.');
+            return;
+        }
+        if (!window.exportBattleResultsImage) {
+            alert('Image export is unavailable.');
+            return;
+        }
+        await window.exportBattleResultsImage(battle.raw_data, { name: battle.name, battle_date: battle.battle_date || '' });
     }
 
     async function deleteBattle(id: string, name: string): Promise<void> {
@@ -206,22 +384,28 @@ import type {
         });
     }
 
-    // ---- admin: dancers (merge duplicates) ----
+    // ---- admin: dancers (rename, merge duplicates) ----
 
     let mergeNameDirty = false; // true once the admin has typed into #ytd-merge-name themselves
+    let lastDancers: DancersResponse['dancers'] = [];
+    let editingDancerId: string | null = null; // dancer row currently showing the rename input
 
     async function loadDancers(): Promise<void> {
         if (!isAdmin) return;
-        let dancers: DancersResponse['dancers'] = [];
         try {
             const res = await fetch('/api/stats/dancers');
-            dancers = ((await res.json()) as DancersResponse).dancers || [];
+            lastDancers = ((await res.json()) as DancersResponse).dancers || [];
         } catch {
-            dancers = [];
+            lastDancers = [];
         }
+        editingDancerId = null;
+        renderDancerRows();
+    }
+
+    function renderDancerRows(): void {
         const body = $('ytd-dancers-body');
         body.innerHTML = '';
-        dancers.forEach((d) => {
+        lastDancers.forEach((d) => {
             const tr = document.createElement('tr');
             const checkCell = document.createElement('td');
             const check = document.createElement('input');
@@ -232,7 +416,45 @@ import type {
             tr.appendChild(checkCell);
 
             const nameCell = document.createElement('td');
-            nameCell.textContent = d.display_name;
+            const actionsCell = document.createElement('td');
+
+            if (editingDancerId === d.id) {
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.value = d.display_name;
+                nameCell.appendChild(input);
+                const errorEl = document.createElement('div');
+                errorEl.className = 'error-message';
+                nameCell.appendChild(errorEl);
+
+                const saveBtn = document.createElement('button');
+                saveBtn.className = 'btn primary small';
+                saveBtn.textContent = 'Save';
+                saveBtn.addEventListener('click', () => void saveDancerRename(d.id, input.value.trim(), errorEl));
+                actionsCell.appendChild(saveBtn);
+
+                const cancelBtn = document.createElement('button');
+                cancelBtn.className = 'btn secondary small';
+                cancelBtn.textContent = 'Cancel';
+                cancelBtn.addEventListener('click', () => {
+                    editingDancerId = null;
+                    renderDancerRows();
+                });
+                actionsCell.appendChild(cancelBtn);
+
+                input.focus();
+                input.select();
+            } else {
+                nameCell.textContent = d.display_name;
+                const renameBtn = document.createElement('button');
+                renameBtn.className = 'btn secondary small';
+                renameBtn.textContent = 'Rename';
+                renameBtn.addEventListener('click', () => {
+                    editingDancerId = d.id;
+                    renderDancerRows();
+                });
+                actionsCell.appendChild(renameBtn);
+            }
             tr.appendChild(nameCell);
 
             const aliasCell = document.createElement('td');
@@ -249,9 +471,36 @@ import type {
             }
             tr.appendChild(battlesCell);
 
+            tr.appendChild(actionsCell);
             body.appendChild(tr);
         });
         updateMergeButtonState();
+    }
+
+    async function saveDancerRename(id: string, newName: string, errorEl: HTMLElement): Promise<void> {
+        errorEl.textContent = '';
+        if (!newName) {
+            errorEl.textContent = 'Name is required.';
+            return;
+        }
+        const res = await fetch(`/api/stats/dancers/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ display_name: newName }),
+        });
+        let data: Partial<ApiErrorResponse>;
+        try {
+            data = (await res.json()) as Partial<ApiErrorResponse>;
+        } catch {
+            data = {};
+        }
+        if (!res.ok) {
+            errorEl.textContent = data.error || 'Failed to rename dancer.';
+            return;
+        }
+        editingDancerId = null;
+        await loadDancers();
+        await loadStandings();
     }
 
     function updateMergeButtonState(): void {
@@ -561,6 +810,7 @@ import type {
             await loadStandings();
             await loadBattles();
         });
+        on('ytd-export-image-btn', 'click', () => void exportYtdImage());
 
         // admin login modal
         on('ytd-admin-login-btn', 'click', () => {

--- a/web/js/ytd.ts
+++ b/web/js/ytd.ts
@@ -3,7 +3,8 @@
  * Self-contained; reuses the existing `.screen`/`.active` show pattern and
  * shared button/table classes. Talks to /api/stats/* and /api/admin/* .
  */
-import { downloadCanvasAsPng, getSocialTheme, isDarkTheme, roundRect, SOCIAL_H, SOCIAL_W } from './socialImage';
+import { downloadCanvasAsPng, fitNameToBox, getSocialTheme, isDarkTheme, roundRect, singleLineBaseline, SOCIAL_H, SOCIAL_W } from './socialImage';
+import type { FitNameResult } from './socialImage';
 import { showToast } from './toast';
 import type {
     AdminLoginResponse,
@@ -119,9 +120,21 @@ import type {
 
     // ---- top-8 social image export (Instagram feed post, 4:5) ----
 
-    /** Draws one ranked "top 8" card (rank, name, points, crowns) — modeled on the
-     * battle-results card chrome in web/js/results.ts's drawSection(), but without
-     * round badges since YTD standings have no per-round data. */
+    interface PlannedYtdRow {
+        fit: FitNameResult;
+        isTop: boolean;
+        height: number;
+    }
+    interface YtdSectionPlan {
+        rows: PlannedYtdRow[];
+        totalHeight: number;
+    }
+
+    /** Draws one ranked "top 8" card (rank, name, points) — modeled on the battle-results
+     * card chrome in web/js/results.ts's drawSection(), but without round badges since YTD
+     * standings have no per-round data. Row heights/name line-wrapping are pre-computed by
+     * exportYtdImage() (via fitNameToBox) and passed in as `plan`, so every row here just
+     * draws whatever it was told to. */
     function drawYtdCard(
         ctx: CanvasRenderingContext2D,
         theme: ReturnType<typeof getSocialTheme>,
@@ -130,12 +143,14 @@ import type {
         startY: number,
         cardX: number,
         cardW: number,
-        rowH: number,
+        nameFontSize: number,
+        rankFontSize: number,
+        plan: YtdSectionPlan,
     ): number {
         const CARD_HEADER_H = 76;
         const CARD_PAD_BOTTOM = 16;
         const CARD_RADIUS = 20;
-        const cardH = CARD_HEADER_H + rows.length * rowH + CARD_PAD_BOTTOM;
+        const cardH = CARD_HEADER_H + plan.totalHeight + CARD_PAD_BOTTOM;
 
         roundRect(ctx, cardX, startY, cardW, cardH, CARD_RADIUS);
         ctx.fillStyle = theme.bgCard;
@@ -162,50 +177,63 @@ import type {
         const rowPad = cardX + 24;
         const rankW = 44;
         const pointsColX = cardX + cardW - 24;
-        const nameFontSize = Math.max(20, Math.min(40, rowH - 26));
-        const rankFontSize = Math.max(16, nameFontSize - 4);
         const nameAreaW = cardW - 48 - rankW - 140;
+        let rowY = rowsStartY;
 
         rows.forEach((row, idx) => {
-            const rowY = rowsStartY + idx * rowH;
-            const textBaseY = rowY + rowH * 0.64;
-            const isTop = idx === 0;
+            const { fit, isTop, height: rowHeight } = plan.rows[idx];
+            const isWrapped = fit.lines.length === 2;
 
             if (idx % 2 === 0) {
                 ctx.fillStyle = theme.rowAlt;
-                ctx.fillRect(cardX + 12, rowY + 1, cardW - 24, rowH - 1);
+                ctx.fillRect(cardX + 12, rowY + 1, cardW - 24, rowHeight - 1);
             }
 
+            // Rank/points baselines: same formula as a normal row; centered instead for a
+            // wrapped row, whose height doesn't match what that formula was tuned for.
+            const rankBaseY = singleLineBaseline(rowY, rowHeight, rankFontSize, isWrapped);
             ctx.fillStyle = theme.textMuted;
             ctx.font = `400 ${rankFontSize}px ${theme.fontMono}`;
             ctx.textAlign = 'left';
-            ctx.fillText((idx + 1) + '.', rowPad, textBaseY);
+            ctx.fillText((idx + 1) + '.', rowPad, rankBaseY);
 
+            // Name (1 or 2 lines, per fitNameToBox) + crown — clipped to the row's full height
+            // so a wrapped second line never spills into the points column.
             ctx.save();
             ctx.beginPath();
-            ctx.rect(rowPad + rankW, rowY, nameAreaW, rowH);
+            ctx.rect(rowPad + rankW, rowY, nameAreaW, rowHeight);
             ctx.clip();
-            const maxChars = Math.floor(nameAreaW / (nameFontSize * 0.54));
-            const displayName = row.display_name.length > maxChars
-                ? row.display_name.slice(0, maxChars - 1) + '…'
-                : row.display_name;
             ctx.fillStyle = isTop ? theme.textPrimary : theme.textSecondary;
-            ctx.font = isTop ? `bold ${nameFontSize}px ${theme.fontBody}` : `400 ${nameFontSize}px ${theme.fontBody}`;
-            ctx.fillText(displayName, rowPad + rankW, textBaseY);
+            ctx.font = isTop ? `bold ${fit.fontSize}px ${theme.fontBody}` : `400 ${fit.fontSize}px ${theme.fontBody}`;
+
+            let lastLineY: number;
+            if (!isWrapped) {
+                lastLineY = singleLineBaseline(rowY, rowHeight, fit.fontSize, false);
+                ctx.fillText(fit.lines[0], rowPad + rankW, lastLineY);
+            } else {
+                const lineGap = fit.fontSize * 1.15;
+                const line1Y = rowY + rowHeight / 2 - lineGap / 2 + fit.fontSize * 0.35;
+                lastLineY = line1Y + lineGap;
+                ctx.fillText(fit.lines[0], rowPad + rankW, line1Y);
+                ctx.fillText(fit.lines[1], rowPad + rankW, lastLineY);
+            }
             if (isTop) {
-                const nameW = ctx.measureText(displayName).width;
-                ctx.font = `${nameFontSize}px serif`;
-                ctx.fillText('👑', rowPad + rankW + nameW + 5, textBaseY);
+                const lastLineW = ctx.measureText(fit.lines[fit.lines.length - 1]).width;
+                ctx.font = `${fit.fontSize}px serif`;
+                ctx.fillText('👑', rowPad + rankW + lastLineW + 5, lastLineY);
             }
             ctx.restore();
 
+            const pointsBaseY = singleLineBaseline(rowY, rowHeight, nameFontSize, isWrapped);
             ctx.textAlign = 'right';
             ctx.fillStyle = theme.textPrimary;
             ctx.font = `bold ${nameFontSize}px ${theme.fontMono}`;
-            ctx.fillText(`${row.total_points} pts`, pointsColX, textBaseY);
+            ctx.fillText(`${row.total_points} pts`, pointsColX, pointsBaseY);
+
+            rowY += rowHeight;
         });
 
-        return rowsStartY + rows.length * rowH + CARD_PAD_BOTTOM;
+        return rowsStartY + plan.totalHeight + CARD_PAD_BOTTOM;
     }
 
     async function exportYtdImage(): Promise<void> {
@@ -257,13 +285,51 @@ import type {
         const availForRows = (H - FOOTER_H) - contentStartY
             - 2 * (CARD_HEADER_H + CARD_PAD_BOTTOM)
             - SECTION_GAP;
-        const rowH = Math.max(40, Math.floor(availForRows / (2 * maxRows)));
 
         const cardX = PAD - 12;
         const cardW = W - 2 * (PAD - 12);
+        const rankW = 44;
+        const nameAreaW = cardW - 48 - rankW - 140;
 
-        const leadsEnd = drawYtdCard(ctx, theme, top8Leads, 'Leads', contentStartY, cardX, cardW, rowH);
-        drawYtdCard(ctx, theme, top8Follows, 'Follows', leadsEnd + SECTION_GAP, cardX, cardW, rowH);
+        // A name that doesn't fit on one line even after shrinking wraps onto two lines
+        // instead of being cut short (see fitNameToBox in socialImage.ts). A wrapped row
+        // needs more vertical room than a normal row; WRAP_ROWS is how much more.
+        const WRAP_ROWS = 1.7;
+
+        let rowH = Math.max(40, Math.floor(availForRows / (2 * maxRows)));
+        let nameFontSize = Math.max(20, Math.min(40, rowH - 26));
+        let rankFontSize = Math.max(16, nameFontSize - 4);
+        let minNameFontSize = Math.max(16, Math.round(nameFontSize * 0.7));
+
+        const planSection = (rows: YtdStandingRow[]): YtdSectionPlan => {
+            let totalHeight = 0;
+            const planned = rows.map((row, idx) => {
+                const isTop = idx === 0;
+                const fit = fitNameToBox(ctx, row.display_name, nameAreaW, nameFontSize, minNameFontSize, theme.fontBody, isTop);
+                const height = fit.lines.length === 2 ? rowH * WRAP_ROWS : rowH;
+                totalHeight += height;
+                return { fit, isTop, height };
+            });
+            return { rows: planned, totalHeight };
+        };
+
+        let leadsPlan = planSection(top8Leads);
+        let followsPlan = planSection(top8Follows);
+        const wrapCount = [...leadsPlan.rows, ...followsPlan.rows].filter(r => r.fit.lines.length === 2).length;
+
+        if (wrapCount > 0) {
+            const effectiveUnits = 2 * maxRows + wrapCount * (WRAP_ROWS - 1);
+            rowH = Math.max(40, Math.floor(availForRows / effectiveUnits));
+            nameFontSize = Math.max(20, Math.min(40, rowH - 26));
+            rankFontSize = Math.max(16, nameFontSize - 4);
+            minNameFontSize = Math.max(16, Math.round(nameFontSize * 0.7));
+
+            leadsPlan = planSection(top8Leads);
+            followsPlan = planSection(top8Follows);
+        }
+
+        const leadsEnd = drawYtdCard(ctx, theme, top8Leads, 'Leads', contentStartY, cardX, cardW, nameFontSize, rankFontSize, leadsPlan);
+        drawYtdCard(ctx, theme, top8Follows, 'Follows', leadsEnd + SECTION_GAP, cardX, cardW, nameFontSize, rankFontSize, followsPlan);
 
         downloadCanvasAsPng(canvas, `hnt-ytd-${year}-top8.png`, () => showToast('Failed to generate image', 'error'));
     }

--- a/web/routes/admin_stats.py
+++ b/web/routes/admin_stats.py
@@ -322,6 +322,28 @@ def stats_list_dancers():
     return jsonify({"dancers": dancers})
 
 
+@bp.route("/api/stats/dancers/<dancer_id>", methods=["PUT"])
+@admin_required
+def stats_rename_dancer(dancer_id):
+    """Rename a single dancer's canonical display name (no merge)."""
+    if stats_repo is None:
+        return jsonify({"error": "Stats database not configured"}), 503
+    data = request.get_json(silent=True) or {}
+    new_name = (data.get("display_name") or "").strip()
+    if not new_name:
+        return jsonify({"error": "display_name is required"}), 400
+
+    try:
+        renamed = stats_repo.rename_dancer(dancer_id, new_name)
+    except DuplicateDancerError as e:
+        return jsonify({"error": str(e)}), 409
+    except StatsError as e:
+        return jsonify({"error": str(e)}), 400
+    if not renamed:
+        return jsonify({"error": "Dancer not found"}), 404
+    return jsonify({"success": True})
+
+
 @bp.route("/api/stats/dancers/merge", methods=["POST"])
 @admin_required
 def stats_merge_dancers():


### PR DESCRIPTION
- Fix the battle-results share image to 1080x1350 (Instagram feed 4:5)
  instead of the previous 1080x1920 story ratio.
- Add a public "Export Top 8 (Instagram Post)" button on the YTD page
  showing the selected year's top-8 leads/follows in the same 4:5 format.
- Add an admin "Instagram Post" button per contributed battle that
  generates the results image from that battle's stored payload.
- Add inline dancer rename in the admin Edit Dancers table (no merge
  required), preserving the old name as an alias for future uploads.

Extracted shared canvas-drawing primitives (theme palette, rounded-rect,
PNG download) into web/js/socialImage.ts, reused by results.ts and ytd.ts.