### PR TITLE
Prelims: bulk roster entry, battle setup handoff, spectator redirect

### DIFF
--- a/BATTLE_RULES_TEST_SUITE_README.md
+++ b/BATTLE_RULES_TEST_SUITE_README.md
@@ -166,15 +166,16 @@ else:
 import unittest
 from battle_rules_test_suite import BattleRulesValidator
 
+
 class MyCustomTests(unittest.TestCase):
     def test_my_scenario(self):
         # Create specific game scenario
         game = create_my_scenario()
-        
+
         # Validate rules
         validator = BattleRulesValidator(game)
         violations = validator.validate_all_rules(validator.capture_state())
-        
+
         # Assert no violations
         self.assertEqual(violations, [], f"Rule violations: {violations}")
 ```

--- a/prelim_logic.py
+++ b/prelim_logic.py
@@ -133,6 +133,9 @@ class Prelim:
         self.selected_leads: List[str] = []
         self.selected_follows: List[str] = []
         self.complete = False
+        # Set once the battle is started from the prefilled setup screen. The prelim
+        # spectator display polls for it and follows the crowd to the battle display.
+        self.battle_session_id: Optional[str] = None
 
         # Computed structures (persisted so they stay stable across reloads).
         self.heats: List[Dict] = []
@@ -489,6 +492,7 @@ class Prelim:
             "selected_leads": self.selected_leads,
             "selected_follows": self.selected_follows,
             "complete": self.complete,
+            "battle_session_id": self.battle_session_id,
             "heats": self.heats,
             "eligible_leads": self.eligible_leads,
             "eligible_follows": self.eligible_follows,
@@ -528,6 +532,7 @@ class Prelim:
         prelim.selected_leads = data.get("selected_leads", [])
         prelim.selected_follows = data.get("selected_follows", [])
         prelim.complete = data.get("complete", False)
+        prelim.battle_session_id = data.get("battle_session_id")
         prelim.heats = data.get("heats", [])
         prelim.eligible_leads = data.get("eligible_leads", [])
         prelim.eligible_follows = data.get("eligible_follows", [])

--- a/prelim_tests.py
+++ b/prelim_tests.py
@@ -424,22 +424,37 @@ class TestPrelimFlaskFlow(unittest.TestCase):
         adv = c.post("/api/prelims/advance_heat", json={"session_id": sid})
         self.assertEqual(adv.get_json()["current_heat_index"], 1)
 
-        # Commit -> a new battle session with the advancers at 0 points.
+        # Commit records the advancers on the prelim; no battle is built yet.
         commit = c.post(
             "/api/prelims/commit_selection",
             json={"session_id": sid, "lead_selections": d["eligible"]["leads"][:10], "follow_selections": []},
         )
         self.assertEqual(commit.status_code, 200)
         cd = commit.get_json()
-        self.assertEqual(len(cd["initial_leads"]), 10)
-        self.assertEqual(len(cd["initial_follows"]), 8)
+        self.assertEqual(cd["session_id"], sid)  # still the prelim session
+        self.assertEqual(len(cd["selection"]["leads"]), 10)
+        self.assertEqual(len(cd["selection"]["follows"]), 8)
+        self.assertNotIn("initial_leads", cd)
 
-        state = c.get(f"/api/prelims/state?session_id={sid}").status_code  # still a prelim
-        self.assertEqual(state, 200)
-        battle = c.get(f"/api/state?session_id={cd['session_id']}").get_json()
-        pts = [x["points"] for x in battle["scoreboard"]["leads"]] + [
-            x["points"] for x in battle["scoreboard"]["follows"]
+        # The selection survives a re-read: /setup?prelim=<id> prefills from this.
+        after = c.get(f"/api/prelims/state?session_id={sid}").get_json()
+        self.assertEqual(after["selection"], cd["selection"])
+        self.assertEqual(after["config"]["judges"], ["J1", "J2"])
+
+        # The setup screen then starts the battle the normal way, at 0 points.
+        battle = c.post(
+            "/api/start_game",
+            json={
+                "leads": after["selection"]["leads"],
+                "follows": after["selection"]["follows"],
+                "judges": ",".join(after["config"]["judges"]),
+            },
+        ).get_json()
+        state = c.get(f"/api/state?session_id={battle['session_id']}").get_json()
+        pts = [x["points"] for x in state["scoreboard"]["leads"]] + [
+            x["points"] for x in state["scoreboard"]["follows"]
         ]
+        self.assertEqual(len(pts), 18)
         self.assertTrue(all(p == 0 for p in pts))
 
     def test_start_heat_and_next_phase_endpoints(self):

--- a/prelim_tests.py
+++ b/prelim_tests.py
@@ -376,6 +376,7 @@ class TestPrelimPersistence(unittest.TestCase):
     def test_round_trip_is_stable(self):
         p = Prelim.create(_names("L", 20), _names("F", 8), lead_spots=10, follow_spots=8, group_size=8)
         p.session_id = "abc123"
+        p.battle_session_id = "battle456"
         p.advance_heat()
         d = p.to_dict()
         self.assertEqual(d["kind"], "prelim")
@@ -384,6 +385,7 @@ class TestPrelimPersistence(unittest.TestCase):
         self.assertEqual(p2.to_dict(), d)
         self.assertEqual(p2.current_heat_index, 1)
         self.assertEqual(p2.session_id, "abc123")
+        self.assertEqual(p2.battle_session_id, "battle456")
 
 
 class TestPrelimFlaskFlow(unittest.TestCase):
@@ -440,6 +442,7 @@ class TestPrelimFlaskFlow(unittest.TestCase):
         after = c.get(f"/api/prelims/state?session_id={sid}").get_json()
         self.assertEqual(after["selection"], cd["selection"])
         self.assertEqual(after["config"]["judges"], ["J1", "J2"])
+        self.assertIsNone(after["battle_session_id"])  # no battle yet
 
         # The setup screen then starts the battle the normal way, at 0 points.
         battle = c.post(
@@ -448,8 +451,15 @@ class TestPrelimFlaskFlow(unittest.TestCase):
                 "leads": after["selection"]["leads"],
                 "follows": after["selection"]["follows"],
                 "judges": ",".join(after["config"]["judges"]),
+                "prelim_session_id": sid,
             },
         ).get_json()
+
+        # The prelim now points at the battle, which is how the prelim spectator
+        # display knows to redirect to /battle/<id>?mode=display.
+        linked = c.get(f"/api/prelims/state?session_id={sid}").get_json()
+        self.assertEqual(linked["battle_session_id"], battle["session_id"])
+
         state = c.get(f"/api/state?session_id={battle['session_id']}").get_json()
         pts = [x["points"] for x in state["scoreboard"]["leads"]] + [
             x["points"] for x in state["scoreboard"]["follows"]

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -3638,6 +3638,16 @@ input.prelims-number-input.dup {
     width: 4.5em;
 }
 
+/* Setup screen — banner shown when the roster came from a committed prelim */
+.setup-prelim-note {
+    border-left: 3px solid var(--accent);
+    background: var(--accent-light);
+    color: var(--text-primary);
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-sm);
+    margin-bottom: var(--space-md);
+}
+
 /* Prelims — bulk "paste a list" roster add */
 .prelims-bulk {
     margin-top: var(--space-sm);

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -3638,6 +3638,29 @@ input.prelims-number-input.dup {
     width: 4.5em;
 }
 
+/* Prelims — bulk "paste a list" roster add */
+.prelims-bulk {
+    margin-top: var(--space-sm);
+}
+.prelims-bulk > summary {
+    cursor: pointer;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    padding: 4px 0;
+}
+.prelims-bulk > summary:hover {
+    color: var(--text-primary);
+}
+.prelims-bulk textarea {
+    width: 100%;
+    margin-bottom: var(--space-sm);
+    font-family: inherit;
+    resize: vertical;
+}
+.prelims-bulk .form-helper-text {
+    margin: var(--space-xs) 0;
+}
+
 /* Prelim setup screen (dedicated) */
 .prelim-setup-cols {
     display: flex;

--- a/web/helpers.py
+++ b/web/helpers.py
@@ -76,6 +76,9 @@ def serialize_prelim(prelim: Prelim) -> dict:
         "eligible": {"leads": prelim.eligible_leads, "follows": prelim.eligible_follows},
         "selection": {"leads": prelim.selected_leads, "follows": prelim.selected_follows},
         "complete": prelim.complete,
+        # Non-null once the battle has been started from this prelim; the spectator
+        # display follows it to /battle/<id>?mode=display.
+        "battle_session_id": prelim.battle_session_id,
     }
 
 

--- a/web/helpers.py
+++ b/web/helpers.py
@@ -57,6 +57,8 @@ def serialize_prelim(prelim: Prelim) -> dict:
             "break_seconds": prelim.break_seconds,
             "intermission_after": prelim.intermission_after,
             "playlist_url": prelim.battle_config.get("playlist_url") or "",
+            # Carried from prelim setup so the battle setup screen can prefill them.
+            "judges": list(prelim.battle_config.get("judges") or []),
         },
         "num_heats": len(prelim.heats),
         "current_heat_index": prelim.current_heat_index,

--- a/web/index.html
+++ b/web/index.html
@@ -246,6 +246,12 @@
                         <input id="prelim-setup-add-lead-bib" type="number" min="1" placeholder="Bib" class="prelims-add-bib" />
                         <button id="prelim-setup-add-lead-btn" class="btn secondary">Add</button>
                     </div>
+                    <details class="prelims-bulk">
+                        <summary>Paste a list</summary>
+                        <p class="form-helper-text">One dancer per line (or a single comma-separated line). Bibs are optional: <code>12 Alice</code>, <code>12. Alice</code> or <code>Alice, 12</code>. Anyone without one gets the next free number.</p>
+                        <textarea id="prelim-setup-bulk-lead" rows="5" placeholder="Alice&#10;Ben&#10;12 Chris"></textarea>
+                        <button id="prelim-setup-bulk-lead-btn" class="btn secondary">Add all</button>
+                    </details>
                     <label class="prelim-setup-spots">Advance
                         <input type="number" id="prelim-setup-lead-spots" min="1" placeholder="all" />
                         leads
@@ -259,6 +265,12 @@
                         <input id="prelim-setup-add-follow-bib" type="number" min="1" placeholder="Bib" class="prelims-add-bib" />
                         <button id="prelim-setup-add-follow-btn" class="btn secondary">Add</button>
                     </div>
+                    <details class="prelims-bulk">
+                        <summary>Paste a list</summary>
+                        <p class="form-helper-text">One dancer per line (or a single comma-separated line). Bibs are optional: <code>12 Dana</code>, <code>12. Dana</code> or <code>Dana, 12</code>. Anyone without one gets the next free number.</p>
+                        <textarea id="prelim-setup-bulk-follow" rows="5" placeholder="Dana&#10;Erin&#10;12 Fran"></textarea>
+                        <button id="prelim-setup-bulk-follow-btn" class="btn secondary">Add all</button>
+                    </details>
                     <label class="prelim-setup-spots">Advance
                         <input type="number" id="prelim-setup-follow-spots" min="1" placeholder="all" />
                         follows

--- a/web/index.html
+++ b/web/index.html
@@ -159,6 +159,7 @@
 
         <div id="setup-screen" class="screen">
             <h2>Competition Setup</h2>
+            <p id="setup-prelim-note" class="form-helper-text setup-prelim-note" style="display:none;"></p>
             <div class="form-group">
                 <label for="lead-names">Lead Names (comma-separated):</label>
                 <textarea id="lead-names" rows="3" placeholder="e.g., John, Michael, David"></textarea>

--- a/web/js/app.ts
+++ b/web/js/app.ts
@@ -1319,6 +1319,9 @@ async function startCompetition(useSimpleContestantJudges: boolean, allowContest
     const contestantJudgingRequested = allowContestantJudging !== false;
     const simpleModeRequested = contestantJudgingRequested && !!useSimpleContestantJudges;
     const randomizeOrder = randomizeOrderToggle ? randomizeOrderToggle.checked : true;
+    // Present on /setup?prelim=<id> (the roster came from a prelim). Sending it links the
+    // battle back to the prelim so its spectator display can redirect here.
+    const prelimSessionId = new URLSearchParams(window.location.search).get('prelim');
 
     if (!leads || !follows || !judges) {
         showToast('Please enter names for leads, follows, and judges.', 'error');
@@ -1340,7 +1343,8 @@ async function startCompetition(useSimpleContestantJudges: boolean, allowContest
                 playlist_url: playlistUrlRaw,
                 simple_contestant_judges: simpleModeRequested,
                 contestant_judging_enabled: contestantJudgingRequested,
-                randomize_order: randomizeOrder
+                randomize_order: randomizeOrder,
+                prelim_session_id: prelimSessionId
             })
         });
         

--- a/web/js/global.d.ts
+++ b/web/js/global.d.ts
@@ -21,6 +21,7 @@ declare global {
         showScreen?: (el: HTMLElement) => void;
         hydrateBattleRoute?: (sessionId: string) => void;
         hydratePrelimRoute?: (sessionId: string) => void;
+        hydrateSetupFromPrelim?: (prelimId: string | null) => void;
         initPrelimSetup?: () => void;
         hydrateResultsRoute?: (sessionId: string | null) => void;
         updateSessionIdDisplay?: () => void;

--- a/web/js/prelim_setup.ts
+++ b/web/js/prelim_setup.ts
@@ -46,6 +46,18 @@ function wireOnce(): void {
     onEnter('prelim-setup-add-follow', 'follow');
     onEnter('prelim-setup-add-lead-bib', 'lead');
     onEnter('prelim-setup-add-follow-bib', 'follow');
+    $('prelim-setup-bulk-lead-btn')?.addEventListener('click', () => addBulk('lead'));
+    $('prelim-setup-bulk-follow-btn')?.addEventListener('click', () => addBulk('follow'));
+    const onCtrlEnter = (id: string, role: 'lead' | 'follow') =>
+        $(id)?.addEventListener('keydown', (e) => {
+            const ke = e as KeyboardEvent;
+            if (ke.key === 'Enter' && (ke.metaKey || ke.ctrlKey)) {
+                ke.preventDefault();
+                addBulk(role);
+            }
+        });
+    onCtrlEnter('prelim-setup-bulk-lead', 'lead');
+    onCtrlEnter('prelim-setup-bulk-follow', 'follow');
     $('prelim-setup-start')?.addEventListener('click', () => {
         void start();
     });
@@ -59,11 +71,12 @@ function usedBibs(exclude?: Entry): Set<string> {
     return s;
 }
 
-// Smallest positive integer not currently assigned to anyone.
-function nextBib(): string {
+// Smallest positive integer not currently assigned to anyone (and not in `reserved`,
+// used by bulk add to hold the explicit bibs that later lines in the paste claim).
+function nextBib(reserved?: Set<string>): string {
     const used = usedBibs();
     let i = 1;
-    while (used.has(String(i))) i += 1;
+    while (used.has(String(i)) || reserved?.has(String(i))) i += 1;
     return String(i);
 }
 
@@ -95,6 +108,100 @@ function addFromInput(role: 'lead' | 'follow'): void {
     if (bibInput) bibInput.value = '';
     render();
     input?.focus();
+}
+
+interface BulkEntry {
+    name: string;
+    bib: string | null;
+}
+
+function unquote(s: string): string {
+    const t = s.trim();
+    return /^".*"$/.test(t) ? t.slice(1, -1).trim() : t;
+}
+
+/**
+ * Parse a pasted roster into name (+ optional bib) entries.
+ *
+ * Text containing a newline is one dancer per line; a single line is treated as a
+ * comma-separated list of names. Within a line a bib may lead ("12 Alice", "12. Alice",
+ * "12,Alice", "12<tab>Alice") or trail after an explicit comma/tab ("Alice, 12") — a bare
+ * trailing number stays part of the name, so "Alice 2" survives intact. Entries that are
+ * only digits are dropped (a stray number is not a name).
+ */
+export function parseBulkList(text: string): BulkEntry[] {
+    const raw = (text || '').replace(/\r/g, '');
+    const chunks = raw.includes('\n') ? raw.split('\n') : raw.split(',');
+    const out: BulkEntry[] = [];
+    for (const chunk of chunks) {
+        const line = unquote(chunk);
+        if (!line || /^\d+$/.test(line)) continue;
+        let bib: string | null = null;
+        let name = line;
+        const lead = /^(\d{1,5})\s*(?:[.)\-:,\t]\s*|\s+)(.+)$/.exec(line);
+        const trail = /^(.+?)[,\t]\s*(\d{1,5})$/.exec(line);
+        if (lead) {
+            bib = String(parseInt(lead[1], 10));
+            name = lead[2];
+        } else if (trail) {
+            name = trail[1];
+            bib = String(parseInt(trail[2], 10));
+        }
+        name = unquote(name).replace(/\s+/g, ' ');
+        if (!name) continue;
+        out.push({ name, bib });
+    }
+    return out;
+}
+
+function summarize(names: string[]): string {
+    return names.length > 5 ? names.slice(0, 5).join(', ') + ` +${names.length - 5} more` : names.join(', ');
+}
+
+function addBulk(role: 'lead' | 'follow'): void {
+    const ta = $(role === 'lead' ? 'prelim-setup-bulk-lead' : 'prelim-setup-bulk-follow') as HTMLTextAreaElement | null;
+    const entries = parseBulkList(ta?.value || '');
+    if (entries.length === 0) {
+        showToast('Nothing to add — paste some names first.', 'error');
+        return;
+    }
+    // Hold every bib the paste asks for up front, so an auto-numbered dancer earlier in the
+    // list can't steal a number a later line spells out explicitly.
+    const alreadyOnList = (name: string) =>
+        roster.some((r) => r.role === role && r.name.toLowerCase() === name.toLowerCase());
+    const reserved = new Set(entries.filter((e) => e.bib !== null && !alreadyOnList(e.name)).map((e) => e.bib as string));
+
+    let added = 0;
+    const dupes: string[] = [];
+    const clashes: string[] = [];
+    for (const e of entries) {
+        if (alreadyOnList(e.name)) {
+            dupes.push(e.name);
+            continue;
+        }
+        if (e.bib !== null && usedBibs().has(e.bib)) {
+            clashes.push(`${e.name} (bib ${e.bib})`);
+            continue;
+        }
+        if (e.bib !== null) reserved.delete(e.bib);
+        roster.push({ name: e.name, role, bib: e.bib ?? nextBib(reserved) });
+        added += 1;
+    }
+    render();
+
+    const skipped = dupes.length + clashes.length;
+    if (added > 0 && ta) {
+        ta.value = '';
+        if (skipped === 0) {
+            const details = ta.closest('details') as HTMLDetailsElement | null;
+            if (details) details.open = false;
+        }
+    }
+    const parts = [`Added ${added} ${role}${added === 1 ? '' : 's'}.`];
+    if (dupes.length) parts.push(`Already on the list: ${summarize(dupes)}.`);
+    if (clashes.length) parts.push(`Bib already taken: ${summarize(clashes)}.`);
+    const type = added === 0 ? 'error' : skipped > 0 ? 'info' : 'success';
+    showToast(parts.join(' '), type, skipped > 0 ? 6000 : 3000);
 }
 
 function remove(entry: Entry): void {

--- a/web/js/prelims.ts
+++ b/web/js/prelims.ts
@@ -513,7 +513,7 @@ function renderDisplay(next: PrelimStateResponse): void {
             timer.textContent = '🎵';
             timer.classList.remove('paused');
         }
-        if (status) status.textContent = 'Music change — get ready to switch partners';
+        if (status) status.textContent = 'Music change';
     } else if (next.running && next.phase === 'break') {
         if (timer) {
             timer.style.display = showTimer ? '' : 'none';

--- a/web/js/prelims.ts
+++ b/web/js/prelims.ts
@@ -14,6 +14,8 @@
  * - Display (/prelims/<id>?mode=display): the rotating-circle visualization for
  *   contestants/spectators — a circle of follows with leads rotating clockwise. It
  *   polls /api/prelims/state (~1s) and renders the current heat/rotation + countdown.
+ *   It keeps polling through selection, and once the battle has been started the
+ *   prelim's battle_session_id sends it on to /battle/<id>?mode=display.
  *
  * Rotation/timer state (current_rotation_index, running, rotation_started_at) lives on
  * the server so both views stay in sync and a reload resumes cleanly.
@@ -470,7 +472,19 @@ function positionChips(): void {
     });
 }
 
+// The battle has been started from this prelim — send the spectator screen after it.
+// A full load (rather than a client-side route) re-runs display-mode detection and
+// starts the battle display from a clean slate; replace() keeps it off the back stack.
+function followBattleDisplay(battleId: string): void {
+    stopTimers();
+    window.location.replace('/battle/' + encodeURIComponent(battleId) + '?mode=display');
+}
+
 function renderDisplay(next: PrelimStateResponse): void {
+    if (next.battle_session_id) {
+        followBattleDisplay(next.battle_session_id);
+        return;
+    }
     state = next;
     heatIndex = next.current_heat_index;
     rotationIndex = next.current_rotation_index;
@@ -487,10 +501,8 @@ function renderDisplay(next: PrelimStateResponse): void {
         if (status) status.style.display = 'none';
         if (selecting) selecting.style.display = '';
         if (selectingText) selectingText.textContent = next.complete ? 'Competitors selected!' : 'Selecting competitors…';
-        if (next.complete && pollTimer !== null) {
-            window.clearInterval(pollTimer); // done — stop polling
-            pollTimer = null;
-        }
+        // Keep polling even once complete: the battle is started from the setup screen a
+        // moment later, and battle_session_id is what sends this screen over to it.
         return;
     }
 

--- a/web/js/prelims.ts
+++ b/web/js/prelims.ts
@@ -5,8 +5,11 @@
  *   now) plus a per-heat Start button. The operator presses Start once dancers are in
  *   place; the client then drives the 45s rotation timer, pushing each rotation change
  *   to the server so the spectator display can mirror it. After the last heat, the
- *   operator picks who advances (selection checklist) and commits, which builds the
- *   main battle (POST /api/prelims/commit_selection) and routes to /battle/<newId>.
+ *   operator picks who advances (selection checklist) and commits
+ *   (POST /api/prelims/commit_selection), which records the advancers on the prelim and
+ *   routes to the normal battle setup screen at /setup?prelim=<id> — prefilled by
+ *   hydrateSetupFromPrelim() below, so the battle options can still be set before
+ *   /api/start_game builds the battle.
  *
  * - Display (/prelims/<id>?mode=display): the rotating-circle visualization for
  *   contestants/spectators — a circle of follows with leads rotating clockwise. It
@@ -18,11 +21,6 @@
 import { apiFetch, postJson } from './api';
 import { showToast } from './toast';
 import type { PrelimStateResponse } from './types';
-
-interface CommitResponse {
-    session_id: string;
-    contestant_judges_warning?: string;
-}
 
 let state: PrelimStateResponse | null = null;
 let prelimId: string | null = null;
@@ -637,13 +635,15 @@ async function confirmSelection(): Promise<void> {
     const btn = $('prelims-confirm-selection') as HTMLButtonElement | null;
     if (btn) btn.disabled = true;
     try {
-        const data = await postJson<CommitResponse>('/api/prelims/commit_selection', {
+        await postJson<PrelimStateResponse>('/api/prelims/commit_selection', {
             session_id: prelimId,
             // Auto-advance roles send [] and the server fills in the full eligible set.
             lead_selections: state.config.lead_needs_cut ? Array.from(leadPicks) : [],
             follow_selections: state.config.follow_needs_cut ? Array.from(followPicks) : [],
         });
-        window.navigate?.('/battle/' + encodeURIComponent(data.session_id));
+        // Hand off to battle setup rather than starting the battle outright, so the
+        // operator can still set judges, points to win, Spotify, etc.
+        window.navigate?.('/setup?prelim=' + encodeURIComponent(prelimId));
     } catch (err) {
         const msg = err instanceof Error ? err.message : 'Failed to advance to the battle.';
         showToast(msg, 'error');
@@ -802,4 +802,51 @@ function escapeAttr(s: string): string {
     return escapeHtml(s);
 }
 
+// ---- handoff to battle setup ----------------------------------------------
+
+function setField(id: string, value: string): void {
+    const el = $(id) as HTMLInputElement | HTMLTextAreaElement | null;
+    if (el) el.value = value;
+}
+
+/**
+ * Prefill the battle setup screen from a committed prelim (/setup?prelim=<id>).
+ *
+ * Only the roster carries over — the advancers, plus the judges and playlist typed at
+ * prelim setup. Every other battle option is left at whatever the form already shows,
+ * which is the point of stopping here instead of starting the battle straight away.
+ * Called with null for a plain /setup visit, which just hides the note.
+ */
+async function hydrateSetupFromPrelim(id: string | null): Promise<void> {
+    const note = $('setup-prelim-note');
+    if (note) note.style.display = 'none';
+    if (!id) return;
+
+    let prelim: PrelimStateResponse;
+    try {
+        prelim = await apiFetch<PrelimStateResponse>(`/api/prelims/state?session_id=${encodeURIComponent(id)}`);
+    } catch {
+        showToast('That prelim was not found or has expired.', 'error');
+        return;
+    }
+    const leads = prelim.selection.leads;
+    const follows = prelim.selection.follows;
+    if (leads.length === 0 && follows.length === 0) {
+        showToast('That prelim has no advancers yet.', 'info');
+        return;
+    }
+
+    setField('lead-names', leads.join(', '));
+    setField('follow-names', follows.join(', '));
+    const judges = prelim.config.judges || [];
+    if (judges.length) setField('judge-names', judges.join(', '));
+    if (prelim.config.playlist_url) setField('playlist-url', prelim.config.playlist_url);
+
+    if (note) {
+        note.textContent = `Roster carried over from prelims — ${leads.length} lead${leads.length === 1 ? '' : 's'} and ${follows.length} follow${follows.length === 1 ? '' : 's'} advanced. Edit anything below before starting.`;
+        note.style.display = '';
+    }
+}
+
 window.hydratePrelimRoute = hydratePrelimRoute;
+window.hydrateSetupFromPrelim = hydrateSetupFromPrelim;

--- a/web/js/router.ts
+++ b/web/js/router.ts
@@ -22,7 +22,15 @@
 
     const routes: Route[] = [
         { re: /^\/$/, enter: () => activate('home-screen') },
-        { re: /^\/setup\/?$/, enter: () => activate('setup-screen') },
+        {
+            re: /^\/setup\/?$/,
+            enter: () => {
+                activate('setup-screen');
+                // ?prelim=<id> arrives from a committed prelim: prefill with its advancers.
+                const prelim = new URLSearchParams(window.location.search).get('prelim');
+                if (typeof window.hydrateSetupFromPrelim === 'function') window.hydrateSetupFromPrelim(prelim);
+            },
+        },
         {
             re: /^\/prelim-setup\/?$/,
             enter: () => {

--- a/web/js/types.ts
+++ b/web/js/types.ts
@@ -286,6 +286,7 @@ export interface PrelimStateResponse {
         break_seconds: number;
         intermission_after: number;
         playlist_url: string;
+        judges: string[];
     };
     num_heats: number;
     current_heat_index: number;

--- a/web/js/types.ts
+++ b/web/js/types.ts
@@ -304,6 +304,8 @@ export interface PrelimStateResponse {
     eligible: { leads: string[]; follows: string[] };
     selection: { leads: string[]; follows: string[] };
     complete: boolean;
+    /** Set once the battle has been started from this prelim (spectator redirect). */
+    battle_session_id: string | null;
 }
 
 // ---- Tie-break flow (/api/end_game + /api/tiebreak/*, web/routes/game.py) ----

--- a/web/routes/game.py
+++ b/web/routes/game.py
@@ -174,6 +174,15 @@ def start_game():
     game, warning = _build_game(lead_names, follow_names, config)
     session_id = repo.create(game)
 
+    # Started from a prelim-prefilled setup screen: point the prelim at the battle so
+    # its spectator display can follow the crowd over to the battle display.
+    prelim_session_id = data.get("prelim_session_id")
+    if prelim_session_id:
+        prelim, error = get_prelim_or_404(prelim_session_id)
+        if not error:
+            prelim.battle_session_id = session_id
+            repo.save(prelim_session_id, prelim)
+
     return jsonify(_start_game_response(game, session_id, config, warning))
 
 

--- a/web/routes/game.py
+++ b/web/routes/game.py
@@ -364,7 +364,7 @@ def prelims_commit_selection():
         return error
 
     try:
-        selected_leads, selected_follows = prelim.commit_selection(
+        prelim.commit_selection(
             data.get("lead_selections", []),
             data.get("follow_selections", []),
         )
@@ -373,12 +373,11 @@ def prelims_commit_selection():
 
     repo.save(session_id, prelim)
 
-    # Build the main battle from the advancers (fresh at 0), reusing the stored config.
-    game, warning = _build_game(selected_leads, selected_follows, prelim.battle_config)
-    new_session_id = repo.create(game)
-
-    response = _start_game_response(game, new_session_id, prelim.battle_config, warning)
-    response["prelim_session_id"] = session_id
+    # No battle is built here: the advancers are handed to the normal battle setup
+    # screen (/setup?prelim=<id>), which prefills from this state and posts the usual
+    # /api/start_game once the operator has picked the battle options.
+    response = serialize_prelim(prelim)
+    response["session_id"] = session_id
     return jsonify(response)
 
 


### PR DESCRIPTION
Four related improvements to the prelims flow, in order.

## Batch add contestants (`ae91db4`)

The prelim setup screen only took one dancer at a time, which is slow for a full roster. Each role column gets a collapsible **Paste a list** panel.

Parsing: multi-line text is one dancer per line; a single line with no newline is a comma-separated list of names. Bibs are optional and may lead or trail — `12 Alice`, `12. Alice`, `12,Alice`, `Alice, 12`, tab-separated from a spreadsheet — but a bare trailing number stays part of the name, so `Alice 2` is not misread. Explicit bibs anywhere in the paste are reserved up front, so an auto-numbered dancer earlier in the list can't steal one a later line spells out.

Bad entries are skipped rather than failing the whole paste: duplicate names and taken bibs are named in the toast, and the panel stays open with the text so it can be fixed. A clean add clears and collapses it.

## "Music change" caption (`d44cb6e`)

Drops the `— get ready to switch partners` tail on the spectator screen during the intermission.

## Hand off to battle setup instead of starting the battle (`883846f`)

Committing the selection jumped straight into the battle, so the battle options (points to win, contestant judging, Spotify) could never be set for a prelim-fed competition — they were locked to whatever the prelim was created with.

`commit_selection` now only records the advancers and returns the prelim state; the client routes to `/setup?prelim=<id>`, which hydrates from `/api/prelims/state` and prefills the roster and guest judges. Everything else stays on the form, and the usual `/api/start_game` builds the battle. Hydrating from the prelim rather than from client memory keeps the prefilled screen reloadable and shareable. As a side effect, commit no longer creates a `Game` the operator may never use.

## Spectator display follows the battle (`e73f844`)

The prelim spectator screen sat on "Competitors selected!" forever — someone had to reload the projector by hand. A prelim now records `battle_session_id` when `/api/start_game` is posted with `prelim_session_id` (sent automatically when setup was reached via `/setup?prelim=<id>`). The display polls for it and does a full `location.replace` to `/battle/<id>?mode=display`, so display-mode detection re-runs and the battle display starts clean. This required the display to keep polling past the commit — it used to stop once the prelim was complete, which was before the battle existed. Only the display redirects; an operator on `/prelims/<id>` stays put.

## Testing

- Full Python suite green (`run_complete_test_suite.py`), ruff check + format clean, `tsc --noEmit` / eslint / esbuild clean.
- `prelim_tests.py` updated for the new commit contract and the prelim→battle link.
- Browser-driven against the dev server: pasting a mixed list produced the expected bibs with duplicates skipped; a real prelim run landed on a prefilled `/setup` that survived reload and started the battle; and with the spectator display open the whole time, it jumped to the battle display within a poll tick of Start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128hzNiYAX7WkxLkd757Tb6