### PR TITLE
Stop clipping the champion's crown in the results image

### DIFF
--- a/web/js/results.ts
+++ b/web/js/results.ts
@@ -11,7 +11,7 @@
 
 import { getResults } from './api';
 import { stopDisplayPolling } from './display';
-import { downloadCanvasAsPng, fitNameToBox, getSocialTheme, isDarkTheme, roundRect, singleLineBaseline, slugify, SOCIAL_H, SOCIAL_W } from './socialImage';
+import { downloadCanvasAsPng, drawCrown, fitCrownedNameToBox, fitNameToBox, getSocialTheme, isDarkTheme, roundRect, slugify, SOCIAL_H, SOCIAL_W } from './socialImage';
 import type { FitNameResult } from './socialImage';
 import { getSpotifyToken, isSpotifyEnabled } from './spotify';
 import { showToast } from './toast';
@@ -1088,11 +1088,14 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
 
     // Badge geometry is shared across both columns (same width) so a given round's badge
     // is the same physical size in the Leads and Follows cards.
-    const rankW = 40;
+    //
+    // Rows lead with the name, not a rank number: this list is in initial queue order, so a
+    // leading "1." reads as a placement it isn't — and that column is worth more as name
+    // width, which is what the champion's crown is drawn inside of (see fitCrownedNameToBox).
+    const NAME_INSET = 24; // aligns row names with the card header's section label
     const nameToBadgeGap = 16;
-    const rowContentW = columnW - 2 * ROW_INSET;
     const badgeAreaW = 230; // widened at the name column's expense so badges render bigger
-    const nameAreaW = rowContentW - rankW - nameToBadgeGap - badgeAreaW;
+    const nameAreaW = columnW - NAME_INSET - nameToBadgeGap - badgeAreaW - ROW_INSET;
     const badgeGap = 4;
     const badgeRowGap = 6;
 
@@ -1138,7 +1141,6 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
     const perLineBadgeCount = Math.floor((badgeAreaW + badgeGap) / (badgeSize + badgeGap));
 
     const nameFontSizeFor = (rowH: number): number => Math.max(20, Math.min(44, rowH - 26));
-    const rankFontSizeFor = (nameFontSize: number): number => Math.max(18, nameFontSize - 4);
     const minNameFontSizeFor = (nameFontSize: number): number => Math.max(18, Math.round(nameFontSize * 0.7));
 
     // A name that doesn't fit on one line even after shrinking wraps onto two lines instead
@@ -1157,7 +1159,6 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
     interface SectionPlan {
         rows: PlannedRow[];
         totalHeight: number;
-        rankFontSize: number;
     }
 
     const roundsFor = (map: Map<string, RoundBadge[]>, name: string): number => (map.get(name) || []).length;
@@ -1167,12 +1168,13 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
     const planColumn = (order: string[], map: Map<string, RoundBadge[]>, topName: string | null, rowHBaseline: number, rowHCap: number): SectionPlan => {
         const buildAt = (rowH: number): SectionPlan => {
             const nameFontSize = nameFontSizeFor(rowH);
-            const rankFontSize = rankFontSizeFor(nameFontSize);
             const minNameFontSize = minNameFontSizeFor(nameFontSize);
             let totalHeight = 0;
             const rows = order.map(name => {
                 const isTop = name === topName;
-                const fit = fitNameToBox(ctx, name, nameAreaW, nameFontSize, minNameFontSize, C.fontBody, isTop);
+                const fit = isTop
+                    ? fitCrownedNameToBox(ctx, name, nameAreaW, nameFontSize, minNameFontSize, C.fontBody)
+                    : fitNameToBox(ctx, name, nameAreaW, nameFontSize, minNameFontSize, C.fontBody, false);
                 const n = roundsFor(map, name);
                 const badgeRowsUsed: 1 | 2 = (badgeRows === 2 && n > perLineBadgeCount) ? 2 : 1;
                 const badgeStackH = badgeRowsUsed === 2 ? (2 * badgeSize + badgeRowGap + 14) : 0;
@@ -1185,7 +1187,7 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
                 totalHeight += height;
                 return { fit, isTop, badgeRowsUsed, height };
             });
-            return { rows, totalHeight, rankFontSize };
+            return { rows, totalHeight };
         };
 
         let plan = buildAt(rowHBaseline);
@@ -1238,8 +1240,7 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
 
         const rowsStartY = startY + CARD_HEADER_H;
         let rowY = rowsStartY;
-        const rowPad = cardX + ROW_INSET;
-        const nameX = rowPad + rankW;
+        const nameX = cardX + NAME_INSET;
         const badgeStartX = nameX + nameAreaW + nameToBadgeGap;
 
         order.forEach((name, idx) => {
@@ -1253,19 +1254,11 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
                 ctx.fillRect(cardX + 4, rowY + 1, columnW - 8, rowHeight - 1);
             }
 
-            // Rank — same baseline formula as a normal row; centered instead for a wrapped row,
-            // whose height doesn't match what that formula was tuned for. Uses the proportional
-            // body font, not the mono font used for badges/points: a monospace "1." reserves a
-            // full fixed-width cell for the narrow "1" glyph, leaving a visible gap before the
-            // period that a proportional font's natural kerning doesn't have.
-            const rankBaseY = singleLineBaseline(rowY, rowHeight, plan.rankFontSize, isWrapped);
-            ctx.fillStyle = C.textMuted;
-            ctx.font = `400 ${plan.rankFontSize}px ${C.fontBody}`;
-            ctx.textAlign = 'left';
-            ctx.fillText((idx + 1) + '.', rowPad, rankBaseY);
+            ctx.textAlign = 'left'; // reset: the previous row's badges left it centered
 
-            // Name (1 or 2 lines, per fitNameToBox) + crown — clipped to the row's full height
-            // so a wrapped second line (or a bleeding crown) never spills into the badge area.
+            // Name (1 or 2 lines, per fitNameToBox) + crown — the crown's width was already
+            // reserved out of the name box (fitCrownedNameToBox), and the clip to the row's
+            // full height is the backstop so nothing ever spills into the badge area.
             ctx.save();
             ctx.beginPath();
             ctx.rect(nameX, rowY, nameAreaW, rowHeight);
@@ -1288,8 +1281,7 @@ function renderBattleResultsCanvas(params: BattleImageParams): HTMLCanvasElement
             }
             if (isTop) {
                 const lastLineW = ctx.measureText(fit.lines[fit.lines.length - 1]).width;
-                ctx.font = `${fit.fontSize}px serif`;
-                ctx.fillText('👑', nameX + lastLineW + 5, lastLineY);
+                drawCrown(ctx, nameX + lastLineW, lastLineY, fit.fontSize);
             }
             ctx.restore();
 

--- a/web/js/socialImage.ts
+++ b/web/js/socialImage.ts
@@ -135,6 +135,44 @@ function truncateToWidth(ctx: CanvasRenderingContext2D, text: string, maxWidth: 
     return text.slice(0, lo) + '…';
 }
 
+// ---- Champion crown ----
+//
+// The crown is drawn immediately after a champion's name, inside the same (narrow) name
+// column, so the space it needs has to come out of the name box before the name is fitted —
+// otherwise the name fills the column and the crown gets clipped away.
+
+const CROWN_GLYPH = '\u{1F451}';
+/** Crown size relative to the name it follows: an emoji at the full name size reads as
+ * oversized next to the text, and every pixel it reserves is taken from the name. */
+const CROWN_SCALE = 0.8;
+/** Gap between the end of the name and the crown. */
+const CROWN_GAP = 6;
+/** A crowned name may shrink further than a normal one before wrapping/truncating: it has
+ * less room to work with, and a slightly smaller champion name reads better than a cut-off one. */
+const CROWNED_MIN_FONT_RATIO = 0.65;
+
+function crownFontSize(nameFontSize: number): number {
+    return Math.round(nameFontSize * CROWN_SCALE);
+}
+
+/** Width a crown claims after a name rendered at `nameFontSize` (gap + glyph). */
+export function crownReserveWidth(ctx: CanvasRenderingContext2D, nameFontSize: number): number {
+    ctx.font = `${crownFontSize(nameFontSize)}px serif`;
+    return CROWN_GAP + ctx.measureText(CROWN_GLYPH).width;
+}
+
+/** Draws the crown right after a champion's name. `nameEndX` is the x the name's last line
+ * ends at, measured in the name's own font; `nameFontSize` is that line's size. */
+export function drawCrown(
+    ctx: CanvasRenderingContext2D,
+    nameEndX: number,
+    baselineY: number,
+    nameFontSize: number,
+): void {
+    ctx.font = `${crownFontSize(nameFontSize)}px serif`;
+    ctx.fillText(CROWN_GLYPH, nameEndX + CROWN_GAP, baselineY);
+}
+
 export interface FitNameResult {
     /** 1 or 2 lines to render, in order. */
     lines: string[];
@@ -188,4 +226,23 @@ export function fitNameToBox(
 
     // Single unbreakable "word" (or wrapping produced no second line) - truncate as the last resort.
     return { lines: [truncateToWidth(ctx, name, maxWidth)], fontSize: minFontSize };
+}
+
+/**
+ * fitNameToBox for a row that also draws a crown (see drawCrown): fits the name into
+ * `maxWidth` minus the crown's reserved width, so name + crown together stay inside the
+ * name column. The reserve is measured at `baseFontSize` while the crown is drawn at the
+ * (never larger) fitted size, so it always has room to spare, never less.
+ */
+export function fitCrownedNameToBox(
+    ctx: CanvasRenderingContext2D,
+    name: string,
+    maxWidth: number,
+    baseFontSize: number,
+    minFontSize: number,
+    fontFamily: string,
+): FitNameResult {
+    const crownW = crownReserveWidth(ctx, baseFontSize);
+    const crownedMin = Math.max(16, Math.round(minFontSize * CROWNED_MIN_FONT_RATIO));
+    return fitNameToBox(ctx, name, maxWidth - crownW, baseFontSize, crownedMin, fontFamily, true);
 }

--- a/web/js/ytd.ts
+++ b/web/js/ytd.ts
@@ -3,7 +3,7 @@
  * Self-contained; reuses the existing `.screen`/`.active` show pattern and
  * shared button/table classes. Talks to /api/stats/* and /api/admin/* .
  */
-import { downloadCanvasAsPng, fitNameToBox, getSocialTheme, isDarkTheme, roundRect, singleLineBaseline, SOCIAL_H, SOCIAL_W } from './socialImage';
+import { downloadCanvasAsPng, drawCrown, fitCrownedNameToBox, fitNameToBox, getSocialTheme, isDarkTheme, roundRect, singleLineBaseline, SOCIAL_H, SOCIAL_W } from './socialImage';
 import type { FitNameResult } from './socialImage';
 import { showToast } from './toast';
 import type {
@@ -224,8 +224,7 @@ import type {
             }
             if (isTop) {
                 const lastLineW = ctx.measureText(fit.lines[fit.lines.length - 1]).width;
-                ctx.font = `${fit.fontSize}px serif`;
-                ctx.fillText('👑', rowPad + rankW + lastLineW + 5, lastLineY);
+                drawCrown(ctx, rowPad + rankW + lastLineW, lastLineY, fit.fontSize);
             }
             ctx.restore();
 
@@ -336,7 +335,9 @@ import type {
                 let totalHeight = 0;
                 const planned = rows.map((row, idx) => {
                     const isTop = idx === 0;
-                    const fit = fitNameToBox(ctx, row.display_name, nameAreaW, nameFontSize, minNameFontSize, theme.fontBody, isTop);
+                    const fit = isTop
+                        ? fitCrownedNameToBox(ctx, row.display_name, nameAreaW, nameFontSize, minNameFontSize, theme.fontBody)
+                        : fitNameToBox(ctx, row.display_name, nameAreaW, nameFontSize, minNameFontSize, theme.fontBody, false);
                     const height = fit.lines.length === 2 ? rowH * WRAP_ROWS : rowH;
                     totalHeight += height;
                     return { fit, isTop, height };


### PR DESCRIPTION
The crown was drawn after the champion's name at nameX + nameWidth + 5, inside a clip rect exactly nameAreaW wide — but the name had been fitted to that same full width, so the crown always landed on or past the right edge. In the August battle that left Gabriel with a ~5px sliver and Rossella (whose name shrank to fill the box) with no crown at all.

Reserve the crown's measured width out of the name box before fitting the name, via a shared fitCrownedNameToBox()/drawCrown() pair in socialImage.ts so the YTD top-8 export gets the same treatment. The reserve is measured at the row's base font size while the crown draws at the (never larger) fitted size, so it can only have room to spare.

To pay for that width, battle rows now lead with the name instead of a rank number: those numbers were initial queue order, not placement, so they read as a placement they aren't. The name column goes 180px -> 208px and names align with the card header's section label. The YTD export keeps its numbers — there they really are the standings rank.


Claude-Session: https://claude.ai/code/session_01XCnFNst4xcTzo137i755rJ